### PR TITLE
fix frozen models in migrations 0004+0005

### DIFF
--- a/helpdesk/migrations/0004_auto__add_field_ticket_due_date.py
+++ b/helpdesk/migrations/0004_auto__add_field_ticket_due_date.py
@@ -67,7 +67,6 @@ class Migration(SchemaMigration):
             'Meta': {'object_name': 'CustomField'},
             'data_type': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
             'decimal_places': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
-            'empty_selection_list': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
             'help_text': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
             'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'label': ('django.db.models.fields.CharField', [], {'max_length': "'30'"}),

--- a/helpdesk/migrations/0005_auto__add_field_customfield_empty_selection_list.py
+++ b/helpdesk/migrations/0005_auto__add_field_customfield_empty_selection_list.py
@@ -176,6 +176,7 @@ class Migration(SchemaMigration):
             'assigned_to': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'assigned_to'", 'null': 'True', 'to': "orm['auth.User']"}),
             'created': ('django.db.models.fields.DateTimeField', [], {'blank': 'True'}),
             'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'due_date': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
             'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'last_escalation': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
             'modified': ('django.db.models.fields.DateTimeField', [], {'blank': 'True'}),


### PR DESCRIPTION
Fixes frozen models in migrations 0004 & 0005, which apparently were swapped.
Only the fix to 0005 is actually necessary, and should be applied before the next migration is created.
An extra empy schema migration to update the frozen models to the latest version would probably be a safer solution, so feel free to reject this and I will submit the other one.
