### PR TITLE
Ticket update with no due date set fails

### DIFF
--- a/helpdesk/views/staff.py
+++ b/helpdesk/views/staff.py
@@ -250,17 +250,14 @@ def update_ticket(request, ticket_id, public=False):
     public = request.POST.get('public', False)
     owner = int(request.POST.get('owner', None))
     priority = int(request.POST.get('priority', ticket.priority))
-    due_date_year = request.POST.get('due_date_year', None)
-    due_date_month = request.POST.get('due_date_month', None)
-    due_date_day = request.POST.get('due_date_day', None)
+    due_date_year = int(request.POST.get('due_date_year', 0))
+    due_date_month = int(request.POST.get('due_date_month', 0))
+    due_date_day = int(request.POST.get('due_date_day', 0))
 
     if not (due_date_year and due_date_month and due_date_day):
         due_date = ticket.due_date
     else:
-        due_date = datetime(
-                int(due_date_year),
-                int(due_date_month),
-                int(due_date_day))
+        due_date = datetime(due_date_year, due_date_month, due_date_day)
     tags = request.POST.get('tags', '')
 
     # We need to allow the 'ticket' and 'queue' contexts to be applied to the


### PR DESCRIPTION
Ticket updates fail if a due date is not specified because datetime is called with parameters (0,0,0).
The test on the due date parts is failing because the widget returns "0" when no value is selected for the date component.
I think most of the validation logic should be moved to the form, but I haven't been able to work on that yet, so this should be considered an interim fix.
