### PR TITLE
Fix for ticket list sorting and pagination

### DIFF
--- a/helpdesk/lib.py
+++ b/helpdesk/lib.py
@@ -153,7 +153,7 @@ def query_to_dict(results, descriptions):
 
 def apply_query(queryset, params):
     """
-    Apply a dict-based set of filters & paramaters to a queryset.
+    Apply a dict-based set of filters & parameters to a queryset.
 
     queryset is a Django queryset, eg MyModel.objects.all() or
              MyModel.objects.filter(user=request.user)
@@ -174,7 +174,7 @@ def apply_query(queryset, params):
         queryset = queryset.filter(params['other_filter'])
 
     sorting = params.get('sorting', None)
-    if not sorting:
+    if sorting:
         sortreverse = params.get('sortreverse', None)
         if sortreverse:
             sorting = "-%s" % sorting
@@ -186,7 +186,7 @@ def apply_query(queryset, params):
 def safe_template_context(ticket):
     """
     Return a dictionary that can be used as a template context to render
-    comments and other details with ticket or queue paramaters. Note that
+    comments and other details with ticket or queue parameters. Note that
     we don't just provide the Ticket & Queue objects to the template as
     they could reveal confidential information. Just imagine these two options:
         * {{ ticket.queue.email_box_password }}

--- a/helpdesk/views/staff.py
+++ b/helpdesk/views/staff.py
@@ -564,7 +564,7 @@ mass_update = staff_member_required(mass_update)
 def ticket_list(request):
     context = {}
 
-    # Query_params will hold a dictionary of paramaters relating to
+    # Query_params will hold a dictionary of parameters relating to
     # a query, to be saved if needed:
     query_params = {
         'filtering': {},
@@ -734,10 +734,8 @@ def ticket_list(request):
 
     user_saved_queries = SavedSearch.objects.filter(Q(user=request.user) | Q(shared__exact=True))
 
-    query_string = []
-    for get_key, get_value in request.GET.iteritems():
-        if get_key != "page":
-            query_string.append("%s=%s" % (get_key, get_value))
+    querydict = request.GET.copy()
+    querydict.pop('page', 1)
 
     tag_choices = [] 
     if HAS_TAG_SUPPORT:
@@ -747,7 +745,7 @@ def ticket_list(request):
     return render_to_response('helpdesk/ticket_list.html',
         RequestContext(request, dict(
             context,
-            query_string="&".join(query_string),
+            query_string=querydict.urlencode(),
             tickets=tickets,
             user_choices=User.objects.filter(is_active=True),
             queue_choices=Queue.objects.all(),


### PR DESCRIPTION
Two fixes:
- the sorting parameter was not considered because the test was inverted;
- when paginating, the querystring would not be properly reconstructed if multiple values were specified for a parameter (e.g. status=1&status=2&status=3 dropped two of the values).
