### PR TITLE
Make sure that blank strings do not kill in_list

### DIFF
--- a/helpdesk/templatetags/in_list.py
+++ b/helpdesk/templatetags/in_list.py
@@ -18,7 +18,7 @@ Assuming 'food' = 'pizza' and 'best_foods' = ['pizza', 'pie', 'cake]:
 from django import template
 
 def in_list(value, arg):
-    return value in arg
+    return value in ( arg or [] )
 
 register = template.Library()
 register.filter(in_list)


### PR DESCRIPTION
Lookups in django's template language can fail gracefully and return empty strings. this fixes the in_string tag to properly deal with empty strings, Nones or Falses.
