### PR TITLE
fix unicode decode error

### DIFF
--- a/helpdesk/management/commands/get_email.py
+++ b/helpdesk/management/commands/get_email.py
@@ -135,9 +135,9 @@ def process_queue(q, quiet=False):
 def decodeUnknown(charset, string):
     if not charset:
         try:
-            return string.decode('utf-8')
+            return string.decode('utf-8','ignore')
         except:
-            return string.decode('iso8859-1')
+            return string.decode('iso8859-1','ignore')
     return unicode(string, charset)
 
 def decode_mail_headers(string):


### PR DESCRIPTION
ignore when some characters can't be decoded to avoid unicode decode error.
