### PR TITLE
Fix the navigation links for NON_STAFF to create new ticket if HELPDESK_...

### DIFF
--- a/helpdesk/templates/helpdesk/navigation.html
+++ b/helpdesk/templates/helpdesk/navigation.html
@@ -27,8 +27,13 @@
 </ul>
 {% else %}
 <ul>
+{% if helpdesk_settings.HELPDESK_ALLOW_NON_STAFF_TICKET_UPDATE %}
+<li><a href='{% url 'helpdesk_dashboard' %}'>{% trans "Dashboard" %}</a></li>
+<li><a href='{% url 'helpdesk_submit' %}'>{% trans "Submit A Ticket" %}</a></li>
+{% else %}
 {% if helpdesk_settings.HELPDESK_SUBMIT_A_TICKET_PUBLIC %}
 <li><a href='{% url 'helpdesk_home' %}'>{% trans "Submit A Ticket" %}</a></li>
+{% endif %}
 {% endif %}
 {% if helpdesk_settings.HELPDESK_KB_ENABLED %}<li><a href='{% url 'helpdesk_kb_index' %}'>{% trans "Knowledgebase" %}</a></li>{% endif %}
 {% if not request.path == '/helpdesk/login/' or user.is_authenticated %}


### PR DESCRIPTION
This code change fix the following problem:

When HELPDESK_ALLOW_NON_STAFF_TICKET_UPDATE is set to True, a NON-STAFF user goes to helpdesk (helpdesk/) will be redirected to the dashboard (helpdesk/dashboard/). But the "Submit A Ticket" nav link points to "helpdesk/", which leads the users to dashboard too. Then there is no link for the user to create a new ticket.

This fix corrects the "Submit A Ticket" link and provides another link to go back to the dashboard for non-staff users.
