### PR TITLE
Fix the bug of handling attachments when Django DEFAULT_FILE_STORAGE is ...

### DIFF
--- a/helpdesk/forms.py
+++ b/helpdesk/forms.py
@@ -11,6 +11,7 @@ from StringIO import StringIO
 
 from django import forms
 from django.forms import extras
+from django.core.files.storage import default_storage
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.utils.translation import ugettext as _
@@ -305,7 +306,10 @@ class TicketForm(forms.Form):
             if file.size < getattr(settings, 'MAX_EMAIL_ATTACHMENT_SIZE', 512000):
                 # Only files smaller than 512kb (or as defined in 
                 # settings.MAX_EMAIL_ATTACHMENT_SIZE) are sent via email.
-                files.append(a.file.path)
+                try:
+                    files.append(a.file.path)
+                except NotImplementedError:
+                    pass
 
         context = safe_template_context(t)
         context['comment'] = f.comment

--- a/helpdesk/models.py
+++ b/helpdesk/models.py
@@ -604,8 +604,9 @@ def attachment_path(instance, filename):
     os.umask(0)
     path = 'helpdesk/attachments/%s/%s' % (instance.followup.ticket.ticket_for_url, instance.followup.id )
     att_path = os.path.join(settings.MEDIA_ROOT, path)
-    if not os.path.exists(att_path):
-        os.makedirs(att_path, 0777)
+    if settings.DEFAULT_FILE_STORAGE == "django.core.files.storage.FileSystemStorage":
+        if not os.path.exists(att_path):
+            os.makedirs(att_path, 0777)
     return os.path.join(path, filename)
 
 


### PR DESCRIPTION
Fix the bug of handling attachments when Django DEFAULT_FILE_STORAGE is not FileSystemStorage.

Passed for storing files into Amazon S3 using the django-s3-folder-storage.
