### PR TITLE
fixes: attachments in public comments not always shown in public_view_ticket

### DIFF
--- a/helpdesk/templates/helpdesk/public_view_ticket.html
+++ b/helpdesk/templates/helpdesk/public_view_ticket.html
@@ -64,11 +64,11 @@
 {% for change in followup.ticketchange_set.all %}
 <li>{% blocktrans with change.field as field and change.old_value as old_value and change.new_value as new_value %}Changed {{ field }} from {{ old_value }} to {{ new_value }}.{% endblocktrans %}</li>
 {% endfor %}
+</ul></div>{% endif %}
 {% for attachment in followup.attachment_set.all %}{% if forloop.first %}<div class='attachments'><ul>{% endif %}
 <li><a href='{{ attachment.file.url }}'>{{ attachment.filename }}</a> ({{ attachment.mime_type }}, {{ attachment.size|filesizeformat }})</li>
 {% if forloop.last %}</ul></div>{% endif %}
 {% endfor %}
-</ul></div>{% endif %}
 </div>
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
if no followup.ticketchange_set.all is available (example: just new comment and a attachment) the attachments of followups were not shown to a public user.
