### PR TITLE
Changed references from auth.User to get_user_model (views, forms & commands)

### DIFF
--- a/helpdesk/forms.py
+++ b/helpdesk/forms.py
@@ -13,8 +13,12 @@ from django import forms
 from django.forms import extras
 from django.core.files.storage import default_storage
 from django.conf import settings
-from django.contrib.auth.models import User
 from django.utils.translation import ugettext as _
+try:
+    from django.contrib.auth import get_user_model
+    User = get_user_model()
+except ImportError:
+    from django.contrib.auth.models import User
 try:
     from django.utils import timezone
 except ImportError:

--- a/helpdesk/management/commands/create_usersettings.py
+++ b/helpdesk/management/commands/create_usersettings.py
@@ -10,7 +10,11 @@ users who don't yet have them.
 
 from django.utils.translation import ugettext as _
 from django.core.management.base import BaseCommand
-from django.contrib.auth.models import User
+try:
+    from django.contrib.auth import get_user_model
+    User = get_user_model()
+except ImportError:
+    from django.contrib.auth.models import User
 
 from helpdesk.models import UserSettings
 from helpdesk.settings import DEFAULT_USER_SETTINGS

--- a/helpdesk/views/api.py
+++ b/helpdesk/views/api.py
@@ -13,7 +13,11 @@ through templates/helpdesk/help_api.html.
 
 from django import forms
 from django.contrib.auth import authenticate
-from django.contrib.auth.models import User
+try:
+    from django.contrib.auth import get_user_model
+    User = get_user_model()
+except ImportError:
+    from django.contrib.auth.models import User
 from django.http import HttpResponse
 from django.shortcuts import render_to_response
 from django.template import loader, Context

--- a/helpdesk/views/feeds.py
+++ b/helpdesk/views/feeds.py
@@ -7,7 +7,11 @@ views/feeds.py - A handful of staff-only RSS feeds to provide ticket details
                  to feed readers or similar software.
 """
 
-from django.contrib.auth.models import User
+try:
+    from django.contrib.auth import get_user_model
+    User = get_user_model()
+except ImportError:
+    from django.contrib.auth.models import User
 from django.contrib.syndication.views import Feed
 from django.core.urlresolvers import reverse
 from django.db.models import Q

--- a/helpdesk/views/staff.py
+++ b/helpdesk/views/staff.py
@@ -11,7 +11,11 @@ from datetime import datetime, timedelta
 import sys
 
 from django.conf import settings
-from django.contrib.auth.models import User
+try:
+    from django.contrib.auth import get_user_model
+    User = get_user_model()
+except ImportError:
+    from django.contrib.auth.models import User
 from django.contrib.auth.decorators import login_required, user_passes_test
 from django.core.files.base import ContentFile
 from django.core.urlresolvers import reverse


### PR DESCRIPTION
Related to #213, completes #192.

get_user_model was not used in views, forms & commands.

I have change the import in the following files to match the one made in the models.py file.
