### PR TITLE
Enable bs3 tooltips with html markup

### DIFF
--- a/helpdesk/templates/helpdesk/ticket_desc_table.html
+++ b/helpdesk/templates/helpdesk/ticket_desc_table.html
@@ -50,7 +50,7 @@
 
 <tr>
     <th>{% trans "Copies To" %}</th>
-    <td>{{ ticketcc_string }} <strong><a class='tooltip' href='{% url 'helpdesk_ticket_cc' ticket.id %}'>{% trans "Manage" %}<span>{% trans "Click here to add / remove people who should receive an e-mail whenever this ticket is updated." %}</span></a></strong>{% if SHOW_SUBSCRIBE %}, <strong><a class='tooltip' href='?subscribe'>{% trans "Subscribe" %}<span>{% trans "Click here to subscribe yourself to this ticket, if you want to receive an e-mail whenever this ticket is updated." %}</span></a></strong>{% endif %}</td>
+    <td>{{ ticketcc_string }} <strong><a data-toggle='tooltip' href='{% url 'helpdesk_ticket_cc' ticket.id %}' title='{% trans "Click here to add / remove people who should receive an e-mail whenever this ticket is updated." %}'>{% trans "Manage" %}</a></strong>{% if SHOW_SUBSCRIBE %}, <strong><a data-toggle='tooltip' href='?subscribe' title='{% trans "Click here to subscribe yourself to this ticket, if you want to receive an e-mail whenever this ticket is updated." %}'>{% trans "Subscribe" %}</a></strong>{% endif %}</td>
 </tr>
 
 <tr>
@@ -62,7 +62,7 @@
         {% empty %}
         <p>{% trans "This ticket has no dependencies." %}</p>
         {% endfor %}
-        <p><a class='tooltip' href='{% url 'helpdesk_ticket_dependency_add' ticket.id %}'>{% trans "Add Dependency" %}<span>{% trans "Click on 'Add Dependency', if you want to make this ticket dependent on another ticket. A ticket may not be closed until all tickets it depends on are closed." %}</span></a></p>
+        <p><a data-toogle='tooltip' href='{% url 'helpdesk_ticket_dependency_add' ticket.id %}' title="{% trans "Click on 'Add Dependency', if you want to make this ticket dependent on another ticket. A ticket may not be closed until all tickets it depends on are closed." %}">{% trans "Add Dependency" %}</a></p>
     </td>
 </tr>
 


### PR DESCRIPTION
This restored the links 'Manage' (Ticket CC) and 'Add Dependency' in Ticket Description Table
