### PR TITLE
Added server templates

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -3,6 +3,13 @@ Installation
 
 django-helpdesk installation isn't difficult, but it requires you have a bit of existing know-how about Django.
 
+Server templates
+----------------
+Server templates allows to create a temporary server to test djando helpdesk. You can also deploy production servers and fork configurations for customization.
+
+- Ubuntu 14.04: https://manageacloud.com/cookbook/django_helpdesk
+- CentOS 7: https://manageacloud.com/cookbook/django_helpdesk_centos_7
+- Amazon Linux: https://manageacloud.com/cookbook/django_helpdesk_amazon_2014032
 
 Getting The Code
 ----------------


### PR DESCRIPTION
Added a server template in the documentation for Ubuntu 14.04 / CentOS 7 and Amazon Linux. This allows users to:
- Have working instructions to install the application from scratch
- Create a temporarily server with a working version of django-helpdesk to play around
- Deploy a production server with djando-helpdesk 

I think this is a great add-on for the documentation. Novice users will be able to run the application with no problem and advanced users has templates that they just need to customise.

Feedback is appreciated!
