### PR TITLE
Fix replace function for custom fields

### DIFF
--- a/helpdesk/forms.py
+++ b/helpdesk/forms.py
@@ -102,7 +102,7 @@ class EditTicketForm(CustomFieldMixin, forms.ModelForm):
         
         for field, value in self.cleaned_data.items():
             if field.startswith('custom_'):
-                field_name = field.replace('custom_', '')
+                field_name = field.replace('custom_', '', 1)
                 customfield = CustomField.objects.get(name=field_name)
                 try:
                     cfv = TicketCustomFieldValue.objects.get(ticket=self.instance, field=customfield)
@@ -229,7 +229,7 @@ class TicketForm(CustomFieldMixin, forms.Form):
         
         for field, value in self.cleaned_data.items():
             if field.startswith('custom_'):
-                field_name = field.replace('custom_', '')
+                field_name = field.replace('custom_', '', 1)
                 customfield = CustomField.objects.get(name=field_name)
                 cfv = TicketCustomFieldValue(ticket=t,
                             field=customfield,
@@ -407,7 +407,7 @@ class PublicTicketForm(CustomFieldMixin, forms.Form):
 
         for field, value in self.cleaned_data.items():
             if field.startswith('custom_'):
-                field_name = field.replace('custom_', '')
+                field_name = field.replace('custom_', '', 1)
                 customfield = CustomField.objects.get(name=field_name)
                 cfv = TicketCustomFieldValue(ticket=t,
                             field=customfield,


### PR DESCRIPTION
Found very interesting bug.

If create custom fields with names:
custom_phone
custom_var1
....
custom_varn

replace function with replace 'custom_custom_phone' to 'phone' and CustomField.objects.get(name=field_name) with throw error.

ps customfields that are dependes on queue is in progress.
