### PR TITLE
Added ManytoMany relation from Queues to CustomFields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.pyc
+build/*
 dist
 django_helpdesk.egg-info
 docs/html/*

--- a/helpdesk/admin.py
+++ b/helpdesk/admin.py
@@ -24,8 +24,9 @@ class FollowUpAdmin(admin.ModelAdmin):
 class KBItemAdmin(admin.ModelAdmin):
     list_display = ('category', 'title', 'last_updated',)
     list_display_links = ('title',)
-   
+
 class CustomFieldAdmin(admin.ModelAdmin):
+    list_filter = ('queues', )
     list_display = ('name', 'label', 'data_type')
 
 class EmailTemplateAdmin(admin.ModelAdmin):

--- a/helpdesk/models.py
+++ b/helpdesk/models.py
@@ -1201,6 +1201,13 @@ class CustomField(models.Model):
     """
     Definitions for custom fields that are glued onto each ticket.
     """
+    queues = models.ManyToManyField(
+        Queue,
+        blank=True,
+        null=True,
+        help_text=_('Leave blank to allow this reply to be used for all '
+            'queues, or select those queues you wish to limit this field to.'),
+        )
 
     name = models.SlugField(
         _('Field Name'),


### PR DESCRIPTION
Rethought/reworked the approach; think you both @rossp @flinz we're right about #293 . Thanks for reviewing - still have my django training wheels on so tried to emulate something I found worked else where... But realized my work last week was WAY too complicated... So instead reevaluated the approach and kept it simple... the django project I'm using as a base for the app is (GeoNode)[https://github.com/GeoNode/geonode]  which has dropped using South for migrations as the models are still dynamic *not my call. I tried adding but it gave me some major errors so sorry I couldn't follow the contributing guidelines to include the migration files w the commit. Have some work else where on the project but should be coming back to it sometime this week with the javascript... but thinking I'll have the split the forms.py file (inline) so it can be controlled by JS via div/template. This PR is a placeholder for the relationship and admin view to be exploded  
