### PR TITLE
Fix form translations

### DIFF
--- a/helpdesk/forms.py
+++ b/helpdesk/forms.py
@@ -15,7 +15,7 @@ from django import forms
 from django.forms import extras
 from django.core.files.storage import default_storage
 from django.conf import settings
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 try:
     from django.contrib.auth import get_user_model
     User = get_user_model()

--- a/helpdesk/forms.py
+++ b/helpdesk/forms.py
@@ -77,7 +77,7 @@ class EditTicketForm(CustomFieldMixin, forms.ModelForm):
     class Meta:
         model = Ticket
         exclude = ('created', 'modified', 'status', 'on_hold', 'resolution', 'last_escalation', 'assigned_to')
-    
+
     def __init__(self, *args, **kwargs):
         """
         Add any custom fields that are defined to the form
@@ -101,7 +101,7 @@ class EditTicketForm(CustomFieldMixin, forms.ModelForm):
 
 
     def save(self, *args, **kwargs):
-        
+
         for field, value in self.cleaned_data.items():
             if field.startswith('custom_'):
                 field_name = field.replace('custom_', '', 1)
@@ -112,7 +112,7 @@ class EditTicketForm(CustomFieldMixin, forms.ModelForm):
                     cfv = TicketCustomFieldValue(ticket=self.instance, field=customfield)
                 cfv.value = value
                 cfv.save()
-        
+
         return super(EditTicketForm, self).save(*args, **kwargs)
 
 
@@ -228,7 +228,7 @@ class TicketForm(CustomFieldMixin, forms.Form):
             except User.DoesNotExist:
                 t.assigned_to = None
         t.save()
-        
+
         for field, value in self.cleaned_data.items():
             if field.startswith('custom_'):
                 field_name = field.replace('custom_', '', 1)
@@ -251,7 +251,7 @@ class TicketForm(CustomFieldMixin, forms.Form):
             }
 
         f.save()
-        
+
         files = []
         if self.cleaned_data['attachment']:
             import mimetypes
@@ -265,9 +265,9 @@ class TicketForm(CustomFieldMixin, forms.Form):
                 )
             a.file.save(file.name, file, save=False)
             a.save()
-            
+
             if file.size < getattr(settings, 'MAX_EMAIL_ATTACHMENT_SIZE', 512000):
-                # Only files smaller than 512kb (or as defined in 
+                # Only files smaller than 512kb (or as defined in
                 # settings.MAX_EMAIL_ATTACHMENT_SIZE) are sent via email.
                 try:
                     files.append([a.filename, a.file])
@@ -276,7 +276,7 @@ class TicketForm(CustomFieldMixin, forms.Form):
 
         context = safe_template_context(t)
         context['comment'] = f.comment
-        
+
         messages_sent_to = []
 
         if t.submitter_email:
@@ -443,9 +443,9 @@ class PublicTicketForm(CustomFieldMixin, forms.Form):
                 )
             a.file.save(file.name, file, save=False)
             a.save()
-            
+
             if file.size < getattr(settings, 'MAX_EMAIL_ATTACHMENT_SIZE', 512000):
-                # Only files smaller than 512kb (or as defined in 
+                # Only files smaller than 512kb (or as defined in
                 # settings.MAX_EMAIL_ATTACHMENT_SIZE) are sent via email.
                 files.append([a.filename, a.file])
 
@@ -549,7 +549,7 @@ class TicketCCForm(forms.ModelForm):
             users = User.objects.filter(is_active=True, is_staff=True).order_by(User.USERNAME_FIELD)
         else:
             users = User.objects.filter(is_active=True).order_by(User.USERNAME_FIELD)
-        self.fields['user'].queryset = users 
+        self.fields['user'].queryset = users
     class Meta:
         model = TicketCC
         exclude = ('ticket',)


### PR DESCRIPTION
Hello,

I'm working with Python 3.4, so I use the Git version of django-helpdesk. And I noticed an annoying problem with the french translations (see attached screenshot). Here is the fix (and a small cleanup commit ;).

![helpdesk-fr-bug](https://cloud.githubusercontent.com/assets/135331/19479886/056392d4-9549-11e6-8c47-0929a495f11f.png)
