### PR TITLE
Added coverage generation to testing, consumed by codecov in CI

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,25 @@
+# .coveragerc to control coverage.py
+# following the example at http://nedbatchelder.com/code/coverage/config.html
+[run]
+branch = True
+include = helpdesk/*
+omit =
+    *helpdesk/south_migrations/*
+    *helpdesk/migrations/*
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    # Don't complain if tests don't hit defensive assertion code:
+    raise AssertionError
+    raise NotImplementedError
+
+    # Don't complain if non-runnable code isn't run:
+    if 0:
+    if __name__ == .__main__.:
+    if __name__==.__main__.:
+
+ignore_errors = True

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ dist
 django_helpdesk.egg-info
 docs/html/*
 docs/doctrees/*
+.coverage
 .project
 .pydevproject

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,13 @@ matrix:
 
 install:
     - pip install argparse
+    - pip install coverage
+    - pip install codecov
     - pip install -q Django==$DJANGO
     - pip install -q -r requirements.txt
 
-script: python quicktest.py helpdesk
+script: 
+    - coverage run --source='.' quicktest.py helpdesk
+
+after_success:
+    - codecov

--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,9 @@ django-helpdesk - A Django powered ticket tracker for small businesses.
 .. image:: https://travis-ci.org/django-helpdesk/django-helpdesk.png?branch=master
     :target: https://travis-ci.org/django-helpdesk/django-helpdesk
 
+.. image:: https://codecov.io/gh/django-helpdesk/django-helpdesk/branch/master/graph/badge.svg
+  :target: https://codecov.io/gh/django-helpdesk/django-helpdesk
+
 Copyright 2009- Ross Poulton and contributors. All Rights Reserved. See LICENSE for details.
 
 django-helpdesk was formerly known as Jutda Helpdesk, named after the 
@@ -99,6 +102,3 @@ https://www.transifex.com/django-helpdesk/django-helpdesk/
 Feel free to request access to contribute your translations.
 
 Pull requests for all other changes are welcome. We're currently trying to add test cases wherever possible, so please continue to include tests with pull requests.
-
-.. image:: https://secure.travis-ci.org/django-helpdesk/django-helpdesk.png?branch=master
-    :target: https://travis-ci.org/django-helpdesk/django-helpdesk


### PR DESCRIPTION
See #431, this makes test coverage automatically checked and visible.

(+4 squashed commits)
Squashed commits:
[dadf579] switched to codecov from coveralls
[76f5184] added badge to Readme; debugging travis script;
[8b2a807] Testing submission to coveralls
[675ac37] Added coveralls support for travis