### PR TITLE
cleanup build-breaking whitespace merge errors

### DIFF
--- a/helpdesk/management/commands/get_email.py
+++ b/helpdesk/management/commands/get_email.py
@@ -61,17 +61,6 @@ class Command(BaseCommand):
     def __init__(self):
         BaseCommand.__init__(self)
 
-        # Django 1.7 uses different way to specify options than 1.8+
-        if VERSION < (1, 8):
-            self.option_list += (
-            make_option(
-                '--quiet',
-                default=False,
-                action='store_true',
-                dest='quiet',
-                help='Hide details about each queue/message as they are processed'),
-        )
-
     help = 'Process django-helpdesk queues and process e-mails via POP3/IMAP or ' \
            'from a local mailbox directory as required, feeding them into the helpdesk.'
 
@@ -96,7 +85,7 @@ def process_email(quiet=False):
 
         logger = logging.getLogger('django.helpdesk.queue.' + q.slug)
         if not q.logging_type or q.logging_type == 'none':
-            logging.disable(logging.CRITICAL) #disable all messages
+            logging.disable(logging.CRITICAL)  # disable all messages
         elif q.logging_type == 'info':
             logger.setLevel(logging.INFO)
         elif q.logging_type == 'warn':
@@ -108,7 +97,7 @@ def process_email(quiet=False):
         elif q.logging_type == 'debug':
             logger.setLevel(logging.DEBUG)
         if quiet:
-            logger.propagate = False # do not propagate to root logger that would log to console
+            logger.propagate = False  # do not propagate to root logger that would log to console
         logdir = q.logging_dir or '/var/log/helpdesk/'
         handler = logging.FileHandler(logdir + q.slug + '_get_email.log')
         logger.addHandler(handler)
@@ -249,7 +238,7 @@ def process_queue(q, logger):
             if ticket:
                 logger.info("Successfully processed message %s, ticket/comment created." % str(m))
                 try:
-                    #unlink(m) #delete message file if ticket was successful
+                    # unlink(m) #delete message file if ticket was successful
                     logger.info("Successfully deleted message %s." % str(m))
                 except:
                     logger.error("Unable to delete message %s." % str(m))
@@ -281,7 +270,7 @@ def decode_mail_headers(string):
     if six.PY2:
         return u' '.join([unicode(msg, charset or 'utf-8') for msg, charset in decoded])
     elif six.PY3:
-        return u' '.join([str(msg,encoding=charset,errors='replace') if charset else str(msg) for msg, charset in decoded])
+        return u' '.join([str(msg, encoding=charset, errors='replace') if charset else str(msg) for msg, charset in decoded])
 
 
 def ticket_from_message(message, queue, logger):

--- a/helpdesk/models.py
+++ b/helpdesk/models.py
@@ -111,7 +111,7 @@ class Queue(models.Model):
     email_box_type = models.CharField(
         _('E-Mail Box Type'),
         max_length=5,
-        choices=(('pop3', _('POP 3')), ('imap', _('IMAP')), ('local',_('Local Directory'))),
+        choices=(('pop3', _('POP 3')), ('imap', _('IMAP')), ('local', _('Local Directory'))),
         blank=True,
         null=True,
         help_text=_('E-Mail server type for creating tickets automatically '
@@ -178,8 +178,8 @@ class Queue(models.Model):
         blank=True,
         null=True,
         help_text=_('If using a local directory, what directory path do you '
-            'wish to poll for new email? Example: /var/lib/mail/helpdesk/'),
-        )
+                    'wish to poll for new email? Example: /var/lib/mail/helpdesk/'),
+    )
 
     permission_name = models.CharField(
         _('Django auth permission name'),
@@ -231,13 +231,13 @@ class Queue(models.Model):
     logging_type = models.CharField(
         _('Logging Type'),
         max_length=5,
-        choices=(('none', _('None')), ('debug', _('Debug')), ('info',_('Information')), ('warn', _('Warning')), ('error', _('Error')), ('crit', _('Critical'))),
+        choices=(('none', _('None')), ('debug', _('Debug')), ('info', _('Information')), ('warn', _('Warning')), ('error', _('Error')), ('crit', _('Critical'))),
         blank=True,
         null=True,
         help_text=_('Set the default logging level. All messages at that '
-            'level or above will be logged to the directory set below. '
-            'If no level is set, logging will be disabled.'),
-        )
+                    'level or above will be logged to the directory set below. '
+                    'If no level is set, logging will be disabled.'),
+    )
 
     logging_dir = models.CharField(
         _('Logging Directory'),
@@ -245,9 +245,9 @@ class Queue(models.Model):
         blank=True,
         null=True,
         help_text=_('If logging is enabled, what directory should we use to '
-            'store log files for this queue? '
-            'If no directory is set, default to /var/log/helpdesk/'),
-        )
+                    'store log files for this queue? '
+                    'If no directory is set, default to /var/log/helpdesk/'),
+    )
 
     default_owner = models.ForeignKey(
         settings.AUTH_USER_MODEL,

--- a/helpdesk/tests/test_get_email.py
+++ b/helpdesk/tests/test_get_email.py
@@ -20,8 +20,9 @@ except ImportError:
     # Python < 3.3
     import mock
 
+
 class GetEmailTestCase(TestCase):
-    #fixtures = ['emailtemplate.json'] # may don't need this, not testing templates here
+    # fixtures = ['emailtemplate.json'] # may not need this, not testing templates here
 
     def setUp(self):
         self.queue_public = Queue.objects.create(title='Queue 1', slug='QQ', allow_public_submission=True, allow_email_submission=True, email_box_type='local', email_box_local_dir='/var/lib/mail/helpdesk/')
@@ -56,6 +57,3 @@ class GetEmailTestCase(TestCase):
             ticket2 = get_object_or_404(Ticket, pk=2)
             self.assertEqual(ticket2.ticket_for_url, "QQ-%s" % ticket2.id)
             self.assertEqual(ticket2.description, "This is the helpdesk comment via email.")
-
-
-


### PR DESCRIPTION
Ooops, sorry about that. I need to remove the ignore whitespace flags from my local git config and remember to wait for Travis to finish the builds before I click that shiny merge button!

This also removes the now unnecessary special-cased option handling for pre-Django 1.8 management commands.