### PR TITLE
Clean and avoid "repeating yourself" on forms.py

### DIFF
--- a/helpdesk/forms.py
+++ b/helpdesk/forms.py
@@ -298,7 +298,7 @@ class AbstractTicketForm(CustomFieldMixin, forms.Form):
             messages_sent_to.append(queue.new_ticket_cc)
 
         if queue.updated_ticket_cc and \
-                queue.updated_ticket_cc != q.new_ticket_cc and \
+                queue.updated_ticket_cc != queue.new_ticket_cc and \
                 queue.updated_ticket_cc not in messages_sent_to:
             send_templated_mail(
                 'newticket_cc',

--- a/helpdesk/forms.py
+++ b/helpdesk/forms.py
@@ -69,9 +69,11 @@ class CustomFieldMixin(object):
         elif field.data_type == 'url':
             fieldclass = forms.URLField
         elif field.data_type == 'ipaddress':
-            fieldclass = forms.IPAddressField
+            fieldclass = forms.GenericIPAddressField
         elif field.data_type == 'slug':
             fieldclass = forms.SlugField
+        else:
+            raise NameError("Unrecognized data_type %s" % field.data_type)
 
         self.fields['custom_%s' % field.name] = fieldclass(**instanceargs)
 


### PR DESCRIPTION
The main commit (the second one) is a-hell-of-a-diff because I took all the repeated code in `TicketForm` and `PublicTicketForm` and put it in an `AbstractTicketForm`.

I found some inconsistencies while translating django-helpdesk, and then understood that they were due to some repeated code and repeated fields between those two forms.

~~However, I have yet to address the failing build on Python 3.4. I don't recall doing any "dangerous stuff" there, but Travis doesn't lie.~~ edit: Nevermind, I must have my fork master somewhat dirty, and it failed. But it is unrelated to this PR because here it seems to be OK regarding tests.
