### PR TITLE
updated travis 3.4 target to latest 3.4.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 
 python:
     - "2.7"
-    - "3.4"
+    - 3.4.4
     - "3.5"
 
 env:


### PR DESCRIPTION
This makes sure latest patches are available.
Before, travis randomly resolved "3.4" into 3.4.2 or 3.4.4.

See https://github.com/travis-ci/travis-ci/issues/4859#issuecomment-257572649