### PR TITLE
Use HTML5 table ordering based on Unix epoch

### DIFF
--- a/helpdesk/templates/helpdesk/ticket_list.html
+++ b/helpdesk/templates/helpdesk/ticket_list.html
@@ -344,7 +344,7 @@ $(document).ready(function() {
                                             <th><a href='{{ ticket.get_absolute_url }}'>{{ ticket.title }}</a></th>
                                             <td>{{ ticket.queue }}</td>
                                             <td>{{ ticket.get_status }}</td>
-                                            <td><span title='{{ ticket.created|date:"r" }}'>{{ ticket.created|naturaltime }}</span></td>
+                                            <td data-order='{{ ticket.created|date:"U" }}'><span title='{{ ticket.created|date:"r" }}'>{{ ticket.created|naturaltime }}</span></td>
                                             <td>{{ ticket.get_assigned_to }}</td>
                                         </tr>
                                         {% empty %}


### PR DESCRIPTION
So turns out HTML5 allows you to add additional data to sort by independently from the displayed data: https://datatables.net/manual/data/orthogonal-data#HTML-5

Also Django has a filter for outputting the Unix time: https://docs.djangoproject.com/en/1.10/ref/templates/builtins/#std:templatefilter-date (see option -U)

So this seems to work great on my end. My only concern is it only prints the number of seconds since epoch, not microseconds, so it may not be totally exactly in chronological order if multiple tickets are submitted within one second (but at that level does it matter?)

This addresses #450 .