### PR TITLE
solves Title changed to . (Null title) on failed attachment upload.

### DIFF
--- a/helpdesk/views/staff.py
+++ b/helpdesk/views/staff.py
@@ -461,7 +461,7 @@ def update_ticket(request, ticket_id, public=False):
 
     files = process_attachments(f, request.FILES.getlist('attachment'))
 
-    if title != ticket.title:
+    if title and title != ticket.title:
         c = TicketChange(
             followup=f,
             field=_('Title'),


### PR DESCRIPTION
Although the primary content of the original version of this patch, PR #393, was handled as a part of PR #463, this part fixes a separate issue, so I rebased it into a separate commit, preserving @pawelmarkowski's authorship. Thanks for the contribution Pawel! 🍰 