### PR TITLE
urlquote email address when used as get query param

### DIFF
--- a/helpdesk/views/public.py
+++ b/helpdesk/views/public.py
@@ -10,6 +10,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
+from django.utils.http import urlquote
 from django.utils.translation import ugettext as _
 
 from helpdesk import settings as helpdesk_settings
@@ -46,7 +47,7 @@ def homepage(request):
                 return HttpResponseRedirect('%s?ticket=%s&email=%s' % (
                     reverse('helpdesk:public_view'),
                     ticket.ticket_for_url,
-                    ticket.submitter_email)
+                    urlquote(ticket.submitter_email))
                 )
     else:
         try:


### PR DESCRIPTION
Fixes previously unnoticed potential bug when redirecting an anonymous user from public ticket submission to ticket detail view if they have used a '+' as part of the user portion of their email address. While it is a valid email just as is, it requires escaping when used in a URL or else we'll client error our own redirect!