### PR TITLE
Fix form end tag placement, and remove duplicate unstyled query box

### DIFF
--- a/helpdesk/templates/helpdesk/ticket_list.html
+++ b/helpdesk/templates/helpdesk/ticket_list.html
@@ -35,119 +35,6 @@ $(document).ready(function() {
 
 {% load in_list %}
 
-<div id="searchtabs" class="row">
-    {% comment %}<ul>
-    <li><a href='#tabfilter'>{% trans "Query Options" %}</a></li>
-    {% if not from_saved_query %}
-    <li><a href='#tabsave'>{% trans "Save This Query" %}</a></li>
-    {% endif %}
-    {% if user_saved_queries %}
-    <li><a href='#tabload'>{% trans "Load Saved Query" %}</a></li>
-    {% endif %}
-    </ul>{% endcomment %}
-
-<div class="panel-group filter-options" id="accordion">
-    <div id='tabfilter' class="panel panel-default">
-    <div class="panel-heading">
-    <h3 class="panel-title">
-        <a data-toggle="collapse" data-parent="#accordion" href="#collapseOne">
-        {% trans "Change Query" %}
-        </a>
-    </h3>
-    </div>
-    <div id="collapseOne" class="panel-collapse collapse in">
-      <div class="panel-body">
-    <form>
-        <select name='select' id='filterBuilderSelect'>
-        <option value='Sort'>{% trans "Sorting" %}</option>
-        <option value='Owner'>{% trans "Owner" %}</option>
-        <option value='Queue'>{% trans "Queue" %}</option>
-        <option value='Status'>{% trans "Status" %}</option>
-        <option value='Keywords'>{% trans "Keywords" %}</option>
-        <option value='Dates'>{% trans "Date Range" %}</option>
-        </select>
-        <input type='button' id='filterBuilderButton' value='+' />
-    {% csrf_token %}</form>
-
-    <form method='get' action='./'>
-    <div class='thumbnail filterBox{% if query_params.sorting %} filterBoxShow{% endif %}' id='filterBoxSort'>
-    <label for='id_sort'>{% trans "Sorting" %}</label>
-    <select id='id_sort' name='sort'>
-        <option value='created'{% ifequal query_params.sorting "created"%} selected='selected'{% endifequal %}>
-            {% trans "Created" %}
-        </option>
-        <option value='title'{% ifequal query_params.sorting "title"%} selected='selected'{% endifequal %}>
-            {% trans "Title" %}
-        </option>
-        <option value='queue'{% ifequal query_params.sorting "queue"%} selected='selected'{% endifequal %}>
-            {% trans "Queue" %}
-        </option>
-        <option value='status'{% ifequal query_params.sorting "status"%} selected='selected'{% endifequal %}>
-            {% trans "Status" %}
-        </option>
-        <option value='priority'{% ifequal query_params.sorting "priority"%} selected='selected'{% endifequal %}>
-            {% trans "Priority" %}
-        </option>
-        <option value='assigned_to'{% ifequal query_params.sorting "assigned_to"%} selected='selected'{% endifequal %}>
-            {% trans "Owner" %}
-        </option>
-    </select>
-    <label for='id_sortreverse'>{% trans "Reverse" %}</label>
-    <input type='checkbox' name='sortreverse' id='id_sortreverse'{% if query_params.sortreverse %} checked='checked'{% endif %} />
-    <p class='filterHelp'>{% trans "Ordering applied to tickets" %}</p>
-    <input type='button' class='filterBuilderRemove' value='-' />
-    </div>
-
-    <div class='thumbnail filterBox{% if query_params.filtering.assigned_to__id__in %} filterBoxShow{% endif %}' id='filterBoxOwner'>
-    <label for='id_owners'>{% trans "Owner(s)" %}</label>
-    <select id='id_owners' name='assigned_to' multiple='selected' size='5'>
-        {% for u in user_choices %}
-        <option value='{{ u.id }}'{% if u.id|in_list:query_params.filtering.assigned_to__id__in %} selected='selected'{% endif %}>
-            {{ u.get_username }}{% ifequal u user %} {% trans "(ME)" %}{% endifequal %}
-        </option>
-        {% endfor %}
-    </select>
-    <p class='filterHelp'>{% trans "Ctrl-Click to select multiple options" %}</p>
-    <input type='button' class='filterBuilderRemove' value='-' />
-    </div>
-
-    <div class='thumbnail filterBox{% if query_params.filtering.queue__id__in %} filterBoxShow{% endif %}' id='filterBoxQueue'>
-    <label for='id_queues'>{% trans "Queue(s)" %}</label><select id='id_queues' name='queue' multiple='selected' size='5'>{% for q in queue_choices %}<option value='{{ q.id }}'{% if q.id|in_list:query_params.filtering.queue__id__in %} selected='selected'{% endif %}>{{ q.title }}</option>{% endfor %}</select>
-    <p class='filterHelp'>{% trans "Ctrl-click to select multiple options" %}</p>
-    <input type='button' class='filterBuilderRemove' value='-' />
-    </div>
-
-    <div class='thumbnail filterBox{% if query_params.filtering.status__in %} filterBoxShow{% endif %}' id='filterBoxStatus'>
-    <label for='id_statuses'>{% trans "Status(es)" %}</label><select id='id_statuses' name='status' multiple='selected' size='5'>{% for s in status_choices %}<option value='{{ s.0 }}'{% if s.0|in_list:query_params.filtering.status__in %} selected='selected'{% endif %}>{{ s.1 }}</option>{% endfor %}</select>
-    <p class='filterHelp'>{% trans "Ctrl-click to select multiple options" %}</p>
-    <input type='button' class='filterBuilderRemove' value='-' />
-    </div>
-
-    <div class='thumbnail filterBox{% if query_params.filtering.created__gte or query_params.filtering.created__lte %} filterBoxShow{% endif %}' id='filterBoxDates'>
-        <label for='id_date_from'>{% trans "Date (From)" %}</label><input type='text' name='date_from' value='{{ query_params.filtering.created__gte }}' id='id_date_from' />
-        <label for='id_date_to'>{% trans "Date (To)" %}</label><input type='text' name='date_to' value='{{ query_params.filtering.created__lte }}' id='id_date_to' />
-    <p class='filterHelp'>{% trans "Use YYYY-MM-DD date format, eg 2011-05-29" %}</p>
-    <input type='button' class='filterBuilderRemove' value='-' />
-    </div>
-
-    <div class='thumbnail filterBox{% if query %} filterBoxShow{% endif %}' id='filterBoxKeywords'>
-    <label for='id_query'>{% trans "Keywords" %}</label><input type='text' name='q' value='{{ query }}' id='id_query' />
-    <p class='filterHelp'>{% trans "Keywords are case-insensitive, and will be looked for in the title, body and submitter fields." %}</p>
-    <input type='button' class='filterBuilderRemove' value='-' />
-    </div>
-    <hr style='clear: both;' />
-    <input class="btn btn-primary" type='submit' value='{% trans "Apply Filter" %}' />
-    {% if from_saved_query and saved_query.user == user %}
-    <p>{% blocktrans with saved_query.title as query_name %}You are currently viewing saved query <strong>"{{ query_name }}"</strong>.{% endblocktrans %} <a href='{% url 'helpdesk:delete_query' saved_query.id %}'>{% trans "Delete Saved Query" %}</a></p>
-    {% endif %}
-    {% if from_saved_query %}
-    <p>{% blocktrans with saved_query.id as query_id %}<a href='../reports/?saved_query={{ query_id }}'>Run a report</a> on this query to see stats and charts for the data listed below.{% endblocktrans %}</p>
-    {% endif %}
-    {% csrf_token %}</form>
-    </div>
-    </div>
-    </div>
-
             <div class="row">
                 <div class="col-lg-12">
                     <div class="panel panel-primary">
@@ -352,7 +239,7 @@ $(document).ready(function() {
                                         {% endfor %}
                                     </tbody>
                                 </table>
-                            {% csrf_token %}</form>
+                            {% csrf_token %}
 
                                 <p><label>{% trans "Select:" %} </label>
                                     <a href='#select_all' id='select_all'><button class="btn btn-primary btn-sm"><i class="fa fa-check-circle"></i>&nbsp;{% trans "All" %}</button></a>
@@ -360,7 +247,8 @@ $(document).ready(function() {
                                     <a href='#select_inverse' id='select_inverse'><button class="btn btn-primary btn-sm"><i class="fa fa-arrows-alt"></i>&nbsp;{% trans "Invert" %}</button></a>
                                 </p>
 
-                                <p><label for='id_mass_action'>{% trans "With Selected Tickets:" %}</label> <select name='action' id='id_mass_action'><option value='take'>{% trans "Take (Assign to me)" %}</option><option value='delete'>{% trans "Delete" %}</option><optgroup label='{% trans "Close" %}'><option value='close'>{% trans "Close (Don't Send E-Mail)" %}</option><option value='close_public'>{% trans "Close (Send E-Mail)" %}</option></optgroup><optgroup label='{% trans "Assign To" %}'><option value='unassign'>{% trans "Nobody (Unassign)" %}</option>{% for u in user_choices %}<option value='assign_{{ u.id }}'>{{ u.get_username }}</option>{% endfor %}</optgroup></select> <button class="btn btn-primary btn-sm"><i class="fa fa-arrow-circle-right"></i>&nbsp;{% trans "Go" %}</button></p>
+                                <p><label for='id_mass_action'>{% trans "With Selected Tickets:" %}</label> <select name='action' id='id_mass_action'><option value='take'>{% trans "Take (Assign to me)" %}</option><option value='delete'>{% trans "Delete" %}</option><optgroup label='{% trans "Close" %}'><option value='close'>{% trans "Close (Don't Send E-Mail)" %}</option><option value='close_public'>{% trans "Close (Send E-Mail)" %}</option></optgroup><optgroup label='{% trans "Assign To" %}'><option value='unassign'>{% trans "Nobody (Unassign)" %}</option>{% for u in user_choices %}<option value='assign_{{ u.id }}'>{{ u.get_username }}</option>{% endfor %}</optgroup></select> <button type="submit" class="btn btn-primary btn-sm"><i class="fa fa-arrow-circle-right"></i>&nbsp;{% trans "Go" %}</button></p>
+                            </form>
                         </div>
                         <!-- /.panel-body -->
                     </div>


### PR DESCRIPTION
Fix form end tag placement, and remove duplicate unstyled query box, to resolve the issue reported in #467 .

Basically, the "Go" button was outside of the form so did nothing. Oops.