### PR TITLE
Make helpdesk work in apps with their own queue models

### DIFF
--- a/helpdesk/models.py
+++ b/helpdesk/models.py
@@ -320,7 +320,7 @@ class Queue(models.Model):
 
             Permission.objects.create(
                 name=_("Permission for queue: ") + self.title,
-                content_type=ContentType.objects.get(model="queue"),
+                content_type=ContentType.objects.get_for_model(self.__class__),
                 codename=basename,
             )
 


### PR DESCRIPTION
To avoid returning multiple content types when creating custom permissions, use ContentType.objects.get_for_model to lookup the content type for helpdesk.models.queue.

Closes #472 