### PR TITLE
Hotfix/imap encoding errors

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -39,6 +39,6 @@ Before django-helpdesk will be much use, you need to do some basic configuration
        EMAIL_HOST_USER = 'YYYYYY@ZZZZ.PPP'
        EMAIL_HOST_PASSWORD = '123456'
 
-8. If you wish to use SOCKS4/5 proxy with Helpdesk Queue email operations, install PySocks manually.
+8. If you wish to use SOCKS4/5 proxy with Helpdesk Queue email operations, install PySocks manually. Please note that mixing both SOCKS and non-SOCKS email sources for different queues is only supported under Python 2; on Python 3, SOCKS proxy support is all-or-nothing: either all queue email sources must use SOCKS or none may use it. If you need this functionality on Python 3 please `let us know <https://github.com/django-helpdesk/django-helpdesk/issues/new>`_.
 
 You're now up and running! Happy ticketing.

--- a/helpdesk/management/commands/get_email.py
+++ b/helpdesk/management/commands/get_email.py
@@ -126,12 +126,8 @@ def process_queue(q, logger):
                                 addr=q.socks_proxy_host,
                                 port=q.socks_proxy_port)
         socket.socket = socks.socksocket
-    else:
-        if six.PY2:
-            socket.socket = socket._socketobject
-        elif six.PY3:
-            import _socket
-            socket.socket = _socket.socket
+    elif six.PY2:
+        socket.socket = socket._socketobject
 
     email_box_type = settings.QUEUE_EMAIL_BOX_TYPE or q.email_box_type
 

--- a/helpdesk/management/commands/get_email.py
+++ b/helpdesk/management/commands/get_email.py
@@ -198,7 +198,7 @@ def process_queue(q, logger):
             for num in msgnums:
                 logger.info("Processing message %s" % num)
                 status, data = server.fetch(num, '(RFC822)')
-                ticket = ticket_from_message(message=encoding.smart_text(data[0][1]), queue=q, logger=logger)
+                ticket = ticket_from_message(message=encoding.smart_text(data[0][1], errors='replace'), queue=q, logger=logger)
                 if ticket:
                     server.store(num, '+FLAGS', '\\Deleted')
                     logger.info("Successfully processed message %s, deleted from IMAP server" % num)


### PR DESCRIPTION
In case you're still available for review @flinz, this is a, perhaps temporary, fix for the two issues that cropped up in #474. No-one was using SOCKS on Python 3 yet unless they were doing all-or-nothing SOCKS anyway, so this won't break any existing installations -- we just might get a request for it if some mixed-SOCKS case wants to upgrade to Py3 in future...