### PR TITLE
Never return None from views.public.create_ticket

### DIFF
--- a/helpdesk/views/public.py
+++ b/helpdesk/views/public.py
@@ -75,6 +75,7 @@ def homepage(request):
 
 
 def view_ticket(request):
+    # TODO: Use a form here, not enough validation on these parameters.
     ticket_req = request.GET.get('ticket', '')
     email = request.GET.get('email', '')
 
@@ -84,13 +85,6 @@ def view_ticket(request):
             ticket = Ticket.objects.get(id=ticket_id, submitter_email__iexact=email)
         except ObjectDoesNotExist:
             error_message = _('Invalid ticket ID or e-mail address. Please try again.')
-
-            return render(request, 'helpdesk/public_view_form.html', {
-                'ticket': False,
-                'email': email,
-                'error_message': error_message,
-                'helpdesk_settings': helpdesk_settings,
-            })
         else:
             if request.user.is_staff:
                 redirect_url = reverse('helpdesk:view', args=[ticket_id])
@@ -124,6 +118,15 @@ def view_ticket(request):
                 'helpdesk_settings': helpdesk_settings,
                 'next': redirect_url,
             })
+    else:
+        error_message = _('Missing ticket ID or e-mail address. Please try again.')
+
+    return render(request, 'helpdesk/public_view_form.html', {
+        'ticket': False,
+        'email': email,
+        'error_message': error_message,
+        'helpdesk_settings': helpdesk_settings,
+    })
 
 
 def change_language(request):

--- a/helpdesk/views/public.py
+++ b/helpdesk/views/public.py
@@ -75,9 +75,8 @@ def homepage(request):
 
 
 def view_ticket(request):
-    # TODO: Use a form here, not enough validation on these parameters.
-    ticket_req = request.GET.get('ticket', '')
-    email = request.GET.get('email', '')
+    ticket_req = request.GET.get('ticket', None)
+    email = request.GET.get('email', None)
 
     if ticket_req and email:
         queue, ticket_id = Ticket.queue_and_id_from_query(ticket_req)
@@ -118,6 +117,8 @@ def view_ticket(request):
                 'helpdesk_settings': helpdesk_settings,
                 'next': redirect_url,
             })
+    elif ticket_req is None and email is None:
+        error_message = None
     else:
         error_message = _('Missing ticket ID or e-mail address. Please try again.')
 


### PR DESCRIPTION
Would create a 500 when user omitted their email. Only a partial improve. Added a TODO: as this view still breaks if passing non-numeric characters to the ID.

I assume this needs a full overhaul really, and some tests. Not a particularly useful view as it is.

Should be returning 400, 403, 404, etc.