### PR TITLE
Added some helpful columns and filters to the follow-up list page.

### DIFF
--- a/helpdesk/admin.py
+++ b/helpdesk/admin.py
@@ -40,6 +40,12 @@ class AttachmentInline(admin.StackedInline):
 @admin.register(FollowUp)
 class FollowUpAdmin(admin.ModelAdmin):
     inlines = [TicketChangeInline, AttachmentInline]
+    list_display = ('ticket_get_ticket_for_url', 'title', 'date', 'ticket', 'user', 'new_status')
+    list_filter = ('user', 'date', 'new_status')
+
+    def ticket_get_ticket_for_url(self, obj):
+        return obj.ticket.ticket_for_url
+    ticket_get_ticket_for_url.short_description = _('Slug')
 
 
 @admin.register(KBItem)


### PR DESCRIPTION
This resolves #414 by adding more columns and filters to the follow-up list page.
The current situation only shows the title of the follow-up, which is often "Updated" or "Opened", so it is hard to find a specific follow-up if you need to hand-edit one.