### PR TITLE
Fixed encoding error in get_email

### DIFF
--- a/helpdesk/management/commands/get_email.py
+++ b/helpdesk/management/commands/get_email.py
@@ -372,6 +372,8 @@ def ticket_from_message(message, queue, logger):
     priority = 2 if high_priority_types & {smtp_priority, smtp_importance} else 3
 
     if ticket is None:
+        if settings.QUEUE_EMAIL_BOX_UPDATE_ONLY:
+            return None
         new = True
         t = Ticket.objects.create(
             title=subject,

--- a/helpdesk/management/commands/get_email.py
+++ b/helpdesk/management/commands/get_email.py
@@ -323,7 +323,10 @@ def ticket_from_message(message, queue, logger):
                     decodeUnknown(part.get_content_charset(), part.get_payload(decode=True))
                 )
                 # workaround to get unicode text out rather than escaped text
-                body = body.encode('ascii').decode('unicode_escape') if six.PY3 else body.encode('utf-8')
+                try:
+                    body = body.encode('ascii').decode('unicode_escape')
+                except UnicodeEncodeError:
+                    body.encode('utf-8')
                 logger.debug("Discovered plain text MIME part")
             else:
                 files.append(

--- a/helpdesk/settings.py
+++ b/helpdesk/settings.py
@@ -133,6 +133,7 @@ QUEUE_EMAIL_BOX_SSL = getattr(settings, 'QUEUE_EMAIL_BOX_SSL', None)
 QUEUE_EMAIL_BOX_HOST = getattr(settings, 'QUEUE_EMAIL_BOX_HOST', None)
 QUEUE_EMAIL_BOX_USER = getattr(settings, 'QUEUE_EMAIL_BOX_USER', None)
 QUEUE_EMAIL_BOX_PASSWORD = getattr(settings, 'QUEUE_EMAIL_BOX_PASSWORD', None)
+QUEUE_EMAIL_BOX_UPDATE_ONLY = getattr(settings, 'QUEUE_EMAIL_BOX_UPDATE_ONLY', False)
 
 # only allow users to access queues that they are members of?
 HELPDESK_ENABLE_PER_QUEUE_STAFF_PERMISSION = getattr(


### PR DESCRIPTION
Fixed an error when get_email reads mails with accent like á é í ó ú