### PR TITLE
Fix `UnicodeEncodeError` when ticket has an special char using python2 and user goes to the admin page.

### DIFF
--- a/helpdesk/models.py
+++ b/helpdesk/models.py
@@ -339,6 +339,7 @@ class Queue(models.Model):
                 pass
 
 
+@python_2_unicode_compatible
 class Ticket(models.Model):
     """
     To allow a ticket to be entered as quickly as possible, only the


### PR DESCRIPTION
See issue: https://github.com/django-helpdesk/django-helpdesk/issues/541