### PR TITLE
Fix get email command

### DIFF
--- a/demo/demodesk/config/settings.py
+++ b/demo/demodesk/config/settings.py
@@ -207,3 +207,8 @@ MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
 # - This is only necessary to make the demo project work, not needed for
 # your own projects unless you make your own fixtures
 FIXTURE_DIRS = [os.path.join(BASE_DIR, 'fixtures')]
+
+try:
+    from .local_settings import *
+except ImportError:
+    pass

--- a/helpdesk/management/commands/get_email.py
+++ b/helpdesk/management/commands/get_email.py
@@ -347,7 +347,7 @@ def ticket_from_message(message, queue, logger):
             try:
                 logger.debug("Try to base64 decode the attachment payload")
                 payloadToWrite = base64.decodestring(payload)
-            except binascii.Error, TypeError:
+            except (binascii.Error, TypeError):
                 logger.debug("Payload was not base64 encoded, using raw bytes")
                 payloadToWrite = payload
             files.append(SimpleUploadedFile(name, part.get_payload(decode=True), mimetypes.guess_type(name)[0]))

--- a/helpdesk/management/commands/get_email.py
+++ b/helpdesk/management/commands/get_email.py
@@ -340,13 +340,14 @@ def ticket_from_message(message, queue, logger):
             if not name:
                 ext = mimetypes.guess_extension(part.get_content_type())
                 name = "part-%i%s" % (counter, ext)
-
             payload = part.get_payload()
+            if isinstance(payload, list):
+                payload = payload.pop().as_string()
             payloadToWrite = payload
             try:
                 logger.debug("Try to base64 decode the attachment payload")
                 payloadToWrite = base64.decodestring(payload)
-            except binascii.Error:
+            except binascii.Error, TypeError:
                 logger.debug("Payload was not base64 encoded, using raw bytes")
                 payloadToWrite = payload
             files.append(SimpleUploadedFile(name, part.get_payload(decode=True), mimetypes.guess_type(name)[0]))

--- a/helpdesk/static/helpdesk/helpdesk-extend.css
+++ b/helpdesk/static/helpdesk/helpdesk-extend.css
@@ -50,7 +50,10 @@ Bootstrap overrides
 #searchtabs {margin-bottom: 20px;}
 
 .row_tablehead, table.table caption {background-color: #dbd5d9;}
-table.table caption {height: 2em; line-height: 2em; font-weight: bold;}
+table.table caption {
+    padding-left: 2em; 
+    line-height: 2em; font-weight: bold;
+}
 table.ticket-stats caption {color: #fbff00; font-style: italic;}
 table.ticket-stats tbody th, table.ticket-stats tbody tr {padding-left: 20px}
 


### PR DESCRIPTION
when i use gmail the payload are a list

https://github.com/django-helpdesk/django-helpdesk/compare/master...zodman:fix_get_email?expand=1#diff-38279aea05eea2eaf213d3c3ac29f6e7R344

css
add a small css for fix the css on KB table 

demodesk.settings

For fast deploy need local_settings import
