### PR TITLE
Fix for Email Issue while pulling CC and ValueError for public homepage

### DIFF
--- a/helpdesk/management/commands/get_email.py
+++ b/helpdesk/management/commands/get_email.py
@@ -412,7 +412,7 @@ def ticket_from_message(message, queue, logger):
         for ccemail in new_cc:
             tcc = TicketCC.objects.create(
                 ticket=t,
-                email=ccemail,
+                email=ccemail.replace('\n', ' ').replace('\r', ' '),
                 can_view=True,
                 can_update=False
             )

--- a/helpdesk/views/public.py
+++ b/helpdesk/views/public.py
@@ -84,6 +84,8 @@ def view_ticket(request):
             ticket = Ticket.objects.get(id=ticket_id, submitter_email__iexact=email)
         except ObjectDoesNotExist:
             error_message = _('Invalid ticket ID or e-mail address. Please try again.')
+        except ValueError:
+            error_message = _('Invalid ticket ID or e-mail address. Please try again.')
         else:
             if request.user.is_staff:
                 redirect_url = reverse('helpdesk:view', args=[ticket_id])


### PR DESCRIPTION
It fixes the way some email providers format the CC field and catch Exception for ValueError at public view ticket function. 