### PR TITLE
line 74 ... - run `syncdb` + run `migrate`

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -71,5 +71,5 @@ Dependencies
 
 1. Python 3.4+ (or 2.7, but deprecated and support will be removed next release)
 2. Django 1.11 or newer
-3. An existing **working** Django project with database etc. If you cannot log into the Admin, you won't get this product working! This means you **must** run `syncdb` **before** you add ``helpdesk`` to your ``INSTALLED_APPS``.
+3. An existing **working** Django project with database etc. If you cannot log into the Admin, you won't get this product working! This means you **must** run `migrate` **before** you add ``helpdesk`` to your ``INSTALLED_APPS``.
 


### PR DESCRIPTION
i think syncdb is obsolete from 1.9 ... or not?