### PR TITLE
Replacement of hard-coded SQL query for issue #601

### DIFF
--- a/helpdesk/views/staff.py
+++ b/helpdesk/views/staff.py
@@ -151,21 +151,6 @@ def dashboard(request):
     else:
         where_clause = """WHERE   q.id = t.queue_id"""
 
-    cursor = connection.cursor()
-    cursor.execute("""
-        SELECT      q.id as queue,
-                    q.title AS name,
-                    COUNT(CASE t.status WHEN '1' THEN t.id WHEN '2' THEN t.id END) AS open,
-                    COUNT(CASE t.status WHEN '3' THEN t.id END) AS resolved,
-                    COUNT(CASE t.status WHEN '4' THEN t.id END) AS closed
-            %s
-            %s
-            GROUP BY queue, name
-            ORDER BY q.id;
-    """ % (from_clause, where_clause))
-
-    dash_tickets = query_to_dict(cursor.fetchall(), cursor.description)
-
     return render(request, 'helpdesk/dashboard.html', {
         'user_tickets': tickets,
         'user_tickets_closed_resolved': tickets_closed_resolved,
@@ -1103,31 +1088,18 @@ def report_index(request):
     #          Open  Resolved
     # Queue 1    10     4
     # Queue 2     4    12
+    Queues = user_queues if user_queues else Queue.objects.all()
 
-    queues = _get_user_queues(request.user).values_list('id', flat=True)
-
-    from_clause = """FROM    helpdesk_ticket t,
-                    helpdesk_queue q"""
-    if queues:
-        where_clause = """WHERE   q.id = t.queue_id AND
-                        q.id IN (%s)""" % (",".join(("%d" % pk for pk in queues)))
-    else:
-        where_clause = """WHERE   q.id = t.queue_id"""
-
-    cursor = connection.cursor()
-    cursor.execute("""
-        SELECT      q.id as queue,
-                    q.title AS name,
-                    COUNT(CASE t.status WHEN '1' THEN t.id WHEN '2' THEN t.id END) AS open,
-                    COUNT(CASE t.status WHEN '3' THEN t.id END) AS resolved,
-                    COUNT(CASE t.status WHEN '4' THEN t.id END) AS closed
-            %s
-            %s
-            GROUP BY queue, name
-            ORDER BY q.id;
-    """ % (from_clause, where_clause))
-
-    dash_tickets = query_to_dict(cursor.fetchall(), cursor.description)
+    dash_tickets = []
+    for queue in Queues:
+        dash_ticket = {
+            'queue': queue.id,
+            'name': queue.title,
+            'open': queue.ticket_set.filter(status__in=[1, 2]).count(),
+            'resolved': queue.ticket_set.filter(status=3).count(),
+            'closed': queue.ticket_set.filter(status=4).count(),
+        }
+        dash_tickets.append(dash_ticket)
 
     return render(request, 'helpdesk/report_index.html', {
         'number_tickets': number_tickets,


### PR DESCRIPTION
Dear django-helpdesk developers,

The error I was having was 
ProgrammingError: (1146, "Table 'projectdev1.helpdesk_ticket' doesn't exist")

where projectdev1 is one of the databases that are being used by our project. This database is not used for storing django-helpdesk tables, instead it is in projectdev2. The cause of the issue appears to be that the router does not re-direct the hard-coded SQL queries to projectdev2 and so they try to reach helpdesk tables on projectdev1.

I removed the unused dash_tickets variable and its calculation (lines 165-168) and modified the case where it is used so that now it relies on model query APIs (lines 1106-1130). This solved the problem for our project. I hope it helps others as well.