### PR TITLE
Fix imaplib 'IMAP' module reference to 'IMAP4'

### DIFF
--- a/helpdesk/management/commands/get_email.py
+++ b/helpdesk/management/commands/get_email.py
@@ -216,7 +216,7 @@ def process_queue(q, logger):
                          q.email_box_pass or
                          settings.QUEUE_EMAIL_BOX_PASSWORD)
             server.select(q.email_box_imap_folder)
-        except imaplib.IMAP.abort:
+        except imaplib.IMAP4.abort:
             logger.error("IMAP login failed. Check that the server is accessible and that the username and password are correct.")
             server.logout()
             sys.exit()


### PR DESCRIPTION
On IMAP login error: 'imaplib' has no 'IMAP' member; maybe 'IMAP4'