### PR TITLE
Don't redirect to staff only ticket submission page

### DIFF
--- a/helpdesk/templates/helpdesk/public_create_ticket.html
+++ b/helpdesk/templates/helpdesk/public_create_ticket.html
@@ -1,0 +1,47 @@
+{% extends "helpdesk/public_base.html" %}
+{% load i18n bootstrap %}
+
+{% block helpdesk_body %}
+
+{% if helpdesk_settings.HELPDESK_SUBMIT_A_TICKET_PUBLIC %}
+<div class="col-xs-6">
+<div class="panel panel-default">
+
+<div class="panel-body">
+    <h2 name='submit'>{% trans "Submit a Ticket" %}</h2>
+<p>{% trans "Please provide as descriptive a title and description as possible." %}</p>
+
+<form role="form" method='post' action='./#submit' enctype='multipart/form-data'>
+<fieldset>
+        {{ form|bootstrap }}
+        {% comment %}
+        {% for field in form %}
+
+            {% if field.is_hidden %}
+                {{ field }}
+            {% else %}
+
+
+            <div class="form-group {% if field.errors %}has-error{% endif %}">
+                <label class="control-label" for='id_{{ field.name }}'>{{ field.label }}</label>{% if not field.field.required %} <span class='form_optional'>{% trans "(Optional)" %}</span>{% endif %}</dt>
+                <div class="input-group">{{ field }}</div>
+                {% if field.errors %}<div class="help-block">{{ field.errors }}</div>{% endif %}
+                {% if field.help_text %}<span class='fhelp-block'>{{ field.help_text }}</span>{% endif %}
+            </div>
+
+        {% endif %}
+
+        {% endfor %}
+        {% endcomment %}
+
+    <div class='buttons form-group'>
+        <input type='submit' class="btn btn-primary" value='{% trans "Submit Ticket" %}' />
+    </div>
+</fieldset>
+
+{% csrf_token %}</form>
+</div>
+</div>
+</div>
+{% endif %}
+{% endblock %}

--- a/helpdesk/templates/helpdesk/public_homepage.html
+++ b/helpdesk/templates/helpdesk/public_homepage.html
@@ -26,7 +26,7 @@
 
 <div class="panel-body">
     <h2 name='submit'>{% trans "Submit a Ticket" %}</h2>
-<p>{% trans "All fields are required." %} {% trans "Please provide as descriptive a title and description as possible." %}</p>
+<p>{% trans "Please provide as descriptive a title and description as possible." %}</p>
 
 <form role="form" method='post' action='./#submit' enctype='multipart/form-data'>
 <fieldset>

--- a/helpdesk/urls.py
+++ b/helpdesk/urls.py
@@ -12,7 +12,7 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.auth import views as auth_views
 from django.views.generic import TemplateView
 
-from helpdesk.decorators import helpdesk_staff_member_required
+from helpdesk.decorators import helpdesk_staff_member_required, protect_view
 from helpdesk import settings as helpdesk_settings
 from helpdesk.views import feeds, staff, public, kb
 
@@ -45,10 +45,6 @@ urlpatterns = [
     url(r'^tickets/update/$',
         staff.mass_update,
         name='mass_update'),
-
-    url(r'^tickets/submit/$',
-        staff.create_ticket,
-        name='submit'),
 
     url(r'^tickets/(?P<ticket_id>[0-9]+)/$',
         staff.view_ticket,
@@ -149,8 +145,12 @@ urlpatterns = [
 
 urlpatterns += [
     url(r'^$',
-        public.homepage,
+        protect_view(public.Homepage.as_view()),
         name='home'),
+
+    url(r'^tickets/submit/$',
+        public.create_ticket,
+        name='submit'),
 
     url(r'^view/$',
         public.view_ticket,

--- a/helpdesk/views/permissions.py
+++ b/helpdesk/views/permissions.py
@@ -1,0 +1,8 @@
+from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
+
+from helpdesk.decorators import is_helpdesk_staff
+
+
+class MustBeStaffMixin(LoginRequiredMixin, UserPassesTestMixin):
+    def test_func(self):
+        return is_helpdesk_staff(self.request.user)

--- a/helpdesk/views/staff.py
+++ b/helpdesk/views/staff.py
@@ -26,6 +26,7 @@ from django.utils.translation import ugettext as _
 from django.utils.html import escape
 from django import forms
 from django.utils import timezone
+from django.views.generic.edit import FormView
 
 from django.utils import six
 
@@ -46,6 +47,7 @@ from helpdesk.models import (
     IgnoreEmail, TicketCC, TicketDependency,
 )
 from helpdesk import settings as helpdesk_settings
+from helpdesk.views.permissions import MustBeStaffMixin
 
 User = get_user_model()
 
@@ -1019,44 +1021,29 @@ def edit_ticket(request, ticket_id):
 edit_ticket = staff_member_required(edit_ticket)
 
 
-@helpdesk_staff_member_required
-def create_ticket(request):
-    if helpdesk_settings.HELPDESK_STAFF_ONLY_TICKET_OWNERS:
-        assignable_users = User.objects.filter(is_active=True, is_staff=True).order_by(User.USERNAME_FIELD)
-    else:
-        assignable_users = User.objects.filter(is_active=True).order_by(User.USERNAME_FIELD)
+class CreateTicketView(MustBeStaffMixin, FormView):
+    template_name = 'helpdesk/create_ticket.html'
+    form_class = TicketForm
 
-    if request.method == 'POST':
-        form = TicketForm(request.POST, request.FILES)
-        form.fields['queue'].choices = [('', '--------')] + [
-            (q.id, q.title) for q in Queue.objects.all()]
-        form.fields['assigned_to'].choices = [('', '--------')] + [
-            (u.id, u.get_username()) for u in assignable_users]
-        if form.is_valid():
-            ticket = form.save(user=request.user)
-            if _has_access_to_queue(request.user, ticket.queue):
-                return HttpResponseRedirect(ticket.get_absolute_url())
-            else:
-                return HttpResponseRedirect(reverse('helpdesk:dashboard'))
-    else:
+    def get_initial(self):
         initial_data = {}
+        request = self.request
         if request.user.usersettings_helpdesk.settings.get('use_email_as_submitter', False) and request.user.email:
             initial_data['submitter_email'] = request.user.email
         if 'queue' in request.GET:
             initial_data['queue'] = request.GET['queue']
+        return initial_data
 
-        form = TicketForm(initial=initial_data)
-        form.fields['queue'].choices = [('', '--------')] + [
-            (q.id, q.title) for q in Queue.objects.all()]
-        form.fields['assigned_to'].choices = [('', '--------')] + [
-            (u.id, u.get_username()) for u in assignable_users]
-        if helpdesk_settings.HELPDESK_CREATE_TICKET_HIDE_ASSIGNED_TO:
-            form.fields['assigned_to'].widget = forms.HiddenInput()
+    def form_valid(self, form):
+        self.ticket = form.save()
+        return super().form_valid(form)
 
-    return render(request, 'helpdesk/create_ticket.html', {'form': form})
-
-
-create_ticket = staff_member_required(create_ticket)
+    def get_success_url(self):
+        request = self.request
+        if _has_access_to_queue(request.user, self.ticket.queue):
+            return self.ticket.get_absolute_url()
+        else:
+            return reverse('helpdesk:dashboard')
 
 
 @helpdesk_staff_member_required


### PR DESCRIPTION
When HELPDESK_SUBMIT_A_TICKET_PUBLIC is set to True, users's should be able to click the "Submit a Ticket" button without being asked to log in.