### PR TITLE
Add user profile links for submiters who have profiles

### DIFF
--- a/helpdesk/models.py
+++ b/helpdesk/models.py
@@ -9,6 +9,7 @@ models.py - Model (and hence database) definitions. This is the core of the
 
 from __future__ import unicode_literals
 from django.contrib.auth.models import Permission
+from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
@@ -580,6 +581,13 @@ class Ticket(models.Model):
         return TicketDependency.objects.filter(ticket=self).filter(
             depends_on__status__in=OPEN_STATUSES).count() == 0
     can_be_resolved = property(_can_be_resolved)
+
+    def get_submitter_userprofile(self):
+        User = get_user_model()
+        try:
+            return User.objects.get(email=self.submitter_email)
+        except User.DoesNotExist:
+            return None
 
     class Meta:
         get_latest_by = "created"

--- a/helpdesk/templates/helpdesk/ticket_desc_table.html
+++ b/helpdesk/templates/helpdesk/ticket_desc_table.html
@@ -38,7 +38,7 @@
                                         <tr>
                                             <td colspan='2'>{{ ticket.resolution|force_escape|urlizetrunc:50|linebreaksbr }}</td>
                                         </tr>{% endif %}
-                                        
+
                                         <tr>
                                             <th>{% trans "Due Date" %}</th>
                                             <td>{{ ticket.due_date|date:"r" }} ({{ ticket.due_date|naturaltime }})</td>
@@ -55,7 +55,9 @@
 
                                         <tr>
                                             <th>{% trans "Submitter E-Mail" %}</th>
-                                            <td>{{ ticket.submitter_email }}{% if user.is_superuser %} <strong><a href='{% url 'helpdesk:email_ignore_add' %}?email={{ ticket.submitter_email }}'><button type="button" class="btn btn-warning btn-xs"><i class="fa fa-eye-slash"></i>&nbsp;{% trans "Ignore" %}</button></a></strong>{% endif %}</td>
+                                            <td>{{ ticket.submitter_email }}
+                                            {% if user.is_superuser %} {% if submitter_userprofile_url %}<strong><a href='{{submitter_userprofile_url}}'><button type="button" class="btn btn-primary btn-xs"><i class="fa fa-address-book"></i>&nbsp;{% trans "Profile" %}</button></a></strong>{% endif %}
+                                            <strong><a href='{% url 'helpdesk:email_ignore_add' %}?email={{ ticket.submitter_email }}'><button type="button" class="btn btn-warning btn-xs"><i class="fa fa-eye-slash"></i>&nbsp;{% trans "Ignore" %}</button></a></strong>{% endif %}</td>
                                         </tr>
 
                                         <tr>

--- a/helpdesk/tests/helpers.py
+++ b/helpdesk/tests/helpers.py
@@ -77,3 +77,12 @@ def create_ticket(**kwargs):
 
 
 HELPDESK_URLCONF = 'helpdesk.urls'
+
+
+def print_response(response, stdout=False):
+    content = response.content.decode()
+    if stdout:
+        print(content)
+    else:
+        with open("response.html", "w") as f:  # pragma: no cover
+            f.write(content)  # pragma: no cover

--- a/helpdesk/views/staff.py
+++ b/helpdesk/views/staff.py
@@ -14,6 +14,7 @@ from django import VERSION as DJANGO_VERSION
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import user_passes_test
+from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 from django.core.exceptions import ValidationError, PermissionDenied
 from django.db import connection
@@ -319,8 +320,18 @@ def view_ticket(request, ticket_id):
     ticketcc_string, show_subscribe = \
         return_ticketccstring_and_show_subscribe(request.user, ticket)
 
+    submitter_userprofile = ticket.get_submitter_userprofile()
+    if submitter_userprofile is not None:
+        content_type = ContentType.objects.get_for_model(submitter_userprofile)
+        submitter_userprofile_url = reverse(
+            'admin:{app}_{model}_change'.format(app=content_type.app_label, model=content_type.model),
+            kwargs={'object_id': submitter_userprofile.id}
+        )
+    else:
+        submitter_userprofile_url = None
     return render(request, 'helpdesk/ticket.html', {
         'ticket': ticket,
+        'submitter_userprofile_url': submitter_userprofile_url,
         'form': form,
         'active_users': users,
         'priorities': Ticket.PRIORITY_CHOICES,

--- a/quicktest.py
+++ b/quicktest.py
@@ -60,8 +60,7 @@ class QuickDjangoTest(object):
             },
         },
     ]
-                
-    SITE_ID = 1
+
 
     def __init__(self, *args, **kwargs):
         self.apps = args
@@ -85,7 +84,9 @@ class QuickDjangoTest(object):
             MIDDLEWARE=self.MIDDLEWARE,
             ROOT_URLCONF='helpdesk.tests.urls',
             STATIC_URL='/static/',
-            TEMPLATES=self.TEMPLATES
+            LOGIN_URL='/helpdesk/login/',
+            TEMPLATES=self.TEMPLATES,
+            SITE_ID=1
         )
 
         from django.test.runner import DiscoverRunner


### PR DESCRIPTION
This adds a user profile link (visible only to admins) to the view ticket page. The link points to the django admin user profile edit view.

![link](https://user-images.githubusercontent.com/1391608/44314235-af2d0880-a416-11e8-924c-37734042f63f.png)

The link is shown only if the email address is the same as that of a user in the system.