### PR TITLE
Fixed login/logout for Django 2.1.

### DIFF
--- a/helpdesk/urls.py
+++ b/helpdesk/urls.py
@@ -185,13 +185,14 @@ urlpatterns += [
 
 urlpatterns += [
     url(r'^login/$',
-        auth_views.login,
-        {'template_name': 'helpdesk/registration/login.html'},
+        auth_views.LoginView.as_view(
+            template_name='helpdesk/registration/login.html'),
         name='login'),
 
     url(r'^logout/$',
-        auth_views.logout,
-        {'template_name': 'helpdesk/registration/login.html', 'next_page': '../'},
+        auth_views.LogoutView.as_view(
+            template_name='helpdesk/registration/login.html',
+            next_page='../'),
         name='logout'),
 ]
 


### PR DESCRIPTION
In django.contrib.auth.views, the login and logout funcs are removed as of Django 2.1 so django-helpdesk version 0.2.9 will prevent Django 2.1 from starting up. Modifying urls.py to use the LoginView/LogoutView classes instead of the login/logout funcs fixes the problem. The classes were introduced in Django 1.11 (when the funcs were deprecated) so this fix will work for all versions of Django supported by django-helpdesk.