### PR TITLE
Added optional serverside processing on datatables that lists all tic…

### DIFF
--- a/helpdesk/lib.py
+++ b/helpdesk/lib.py
@@ -344,6 +344,7 @@ ORDER_COLUMN_CHOICES = Choices(
     ('8', 'assigned_to')
 )
 
+
 def query_tickets_by_args(objects, order_by, **kwargs):
     """
     This function takes in a list of ticket objects from the views and throws it
@@ -370,13 +371,13 @@ def query_tickets_by_args(objects, order_by, **kwargs):
 
     if search_value:
         queryset = queryset.filter(Q(id__icontains=search_value) |
-                                    Q(priority__icontains=search_value) |
-                                    Q(title__icontains=search_value) |
-                                    Q(queue__title__icontains=search_value) |
-                                    Q(status__icontains=search_value) |
-                                    Q(created__icontains=search_value) |
-                                    Q(due_date__icontains=search_value) |
-                                    Q(assigned_to__email__icontains=search_value))
+                                   Q(priority__icontains=search_value) |
+                                   Q(title__icontains=search_value) |
+                                   Q(queue__title__icontains=search_value) |
+                                   Q(status__icontains=search_value) |
+                                   Q(created__icontains=search_value) |
+                                   Q(due_date__icontains=search_value) |
+                                   Q(assigned_to__email__icontains=search_value))
 
     count = queryset.count()
     queryset = queryset.order_by(order_column)[start:start + length]
@@ -385,4 +386,4 @@ def query_tickets_by_args(objects, order_by, **kwargs):
         'count': count,
         'total': total,
         'draw': draw
-}
+    }

--- a/helpdesk/serializers.py
+++ b/helpdesk/serializers.py
@@ -1,0 +1,48 @@
+from rest_framework import serializers
+
+from .models import Ticket
+
+from django.contrib.humanize.templatetags import humanize
+
+"""
+A serializer for the Ticket model, returns data in the format as required by
+datatables for ticket_list.html. Called from staff.datatables_ticket_list.
+
+"""
+
+class TicketSerializer(serializers.ModelSerializer):
+    ticket = serializers.SerializerMethodField()
+    assigned_to = serializers.SerializerMethodField()
+    created = serializers.SerializerMethodField()
+    due_date = serializers.SerializerMethodField()
+    status = serializers.SerializerMethodField()
+    row_class = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Ticket
+        # fields = '__all__'
+        fields = ('ticket', 'id', 'priority', 'title', 'queue', 'status', 'created', 'due_date', 'assigned_to', 'row_class')
+
+    def get_ticket(self, obj):
+        return (str(obj.id)+" "+obj.ticket)
+
+    def get_status(self, obj):
+        return (obj.get_status)
+
+    def get_created(self, obj):
+        return (humanize.naturaltime(obj.created))
+
+    def get_due_date(self, obj):
+        return (humanize.naturaltime(obj.due_date))
+
+    def get_assigned_to(self, obj):
+        if obj.assigned_to:
+            if obj.assigned_to.first_name:
+                return (obj.assigned_to.first_name)
+            else:
+                return (obj.assigned_to.email)
+        else:
+            return ("None")
+
+    def get_row_class(self, obj):
+        return (obj.get_priority_css_class)

--- a/helpdesk/serializers.py
+++ b/helpdesk/serializers.py
@@ -10,6 +10,7 @@ datatables for ticket_list.html. Called from staff.datatables_ticket_list.
 
 """
 
+
 class TicketSerializer(serializers.ModelSerializer):
     ticket = serializers.SerializerMethodField()
     assigned_to = serializers.SerializerMethodField()
@@ -24,7 +25,7 @@ class TicketSerializer(serializers.ModelSerializer):
         fields = ('ticket', 'id', 'priority', 'title', 'queue', 'status', 'created', 'due_date', 'assigned_to', 'row_class')
 
     def get_ticket(self, obj):
-        return (str(obj.id)+" "+obj.ticket)
+        return (str(obj.id) + " " + obj.ticket)
 
     def get_status(self, obj):
         return (obj.get_status)

--- a/helpdesk/settings.py
+++ b/helpdesk/settings.py
@@ -150,3 +150,7 @@ QUEUE_EMAIL_BOX_UPDATE_ONLY = getattr(settings, 'QUEUE_EMAIL_BOX_UPDATE_ONLY', F
 # only allow users to access queues that they are members of?
 HELPDESK_ENABLE_PER_QUEUE_STAFF_PERMISSION = getattr(
     settings, 'HELPDESK_ENABLE_PER_QUEUE_STAFF_PERMISSION', False)
+
+
+# Asynchronous Datatables - Optional
+USE_SERVERSIDE_PROCESSING = True

--- a/helpdesk/templates/helpdesk/ticket_list.html
+++ b/helpdesk/templates/helpdesk/ticket_list.html
@@ -6,32 +6,100 @@
 
 <script src='{% static "helpdesk/filter.js" %}'></script>
 <script>
-$(document).ready(function() {
+    {% if server_side %}
+        $(document).ready(function()
+        {
+          let url = ""
+            //DataTables Initialization
+            let tasks_table = $('#ticketTable').DataTable({
+                "language": {
+                    "emptyTable": "{% trans 'No Tickets Match Your Selection' %}"
+                },
+                "processing": true,
+                "serverSide": true,
+                "ajax": {
+                    "url": "/datatables_ticket_list/",
+                    "type": "GET",
+                },
+                createdRow: function( row, data, dataIndex )
+                {
+                    $( row ).addClass(data.row_class);
+                },
 
-    $('#ticketTable').DataTable({
-            "oLanguage": {
-                "sEmptyTable": "{% trans 'No Tickets Match Your Selection' %}"
-            },
-            "order": [],
-            responsive: true
-    });
-
-    $("#select_all").click(function() {
-        $(".ticket_multi_select").attr('checked', true);
-        return false;
-    });
-    $("#select_none").click(function() {
-        $(".ticket_multi_select").attr('checked', false);
-        return false;
-    });
-    $("#select_inverse").click(function() {
-        $(".ticket_multi_select").each(function() {
-            $(this).attr('checked', !$(this).attr('checked'));
+                "columns": [
+                  {"data": "ticket",
+                    "render": function (data, type, row, meta)
+                    {
+                        var id = data.split(" ")[0];
+                        var name = data.split(" ")[1];
+                        let url = "{% url 'helpdesk:view' 1234 %}".replace(/1234/, id.toString());
+                        if (type === 'display')
+                        {
+                          data = '<b><a href="' + url + '" >' + name + '</a></b>';
+                        }
+                        return data
+                    }
+                  },
+                  {"data": "id",
+                    "orderable": false,
+                    "render": function(data, type, row, meta)
+                    {
+                      var pk = data;
+                      if(type === 'display'){
+                        data = "<input type='checkbox' name='ticket_id' value='"+pk+"'"+ "class='ticket_multi_select' />"
+                      }
+                        return data
+                      }
+                  },
+                  {"data": "priority"},
+                  {"data": "title",
+                    "render": function (data, type, row, meta)
+                    {
+                      if (type === 'display')
+                      {
+                        data = '<b><a href="' + url + '" >' + data + '</a></b>';
+                      }
+                      return data
+                    }
+                  },
+                  {"data": "queue"},
+                  {"data": "status"},
+                  {"data": "created"},
+                  {"data": "due_date"},
+                  {"data": "assigned_to"},
+                ]
+            });
+          })
+    {% else %}
+        $('#ticketTable').DataTable({
+          "oLanguage": {
+              "sEmptyTable": "{% trans 'No Tickets Match Your Selection' %}"
+          },
+          "order": [],
+          responsive: true
         });
-        return false;
-    });
-});
+    {% endif %}
+    $(document).ready(function()
+    {
+        $("#select_all").click(function() {
+        $(".ticket_multi_select").attr('checked', true);
+            return false;
+        });
+        $("#select_none").click(function() {
+            $(".ticket_multi_select").attr('checked', false);
+            return false;
+        });
+        $("#select_inverse").click(function() {
+            $(".ticket_multi_select").each(function() {
+                $(this).attr('checked', !$(this).attr('checked'));
+            });
+            return false;
+        });
+      })
 </script>
+
+
+
 {% endblock %}
 {% block h1_title %}Tickets
     {% if from_saved_query %} [{{ saved_query.title }}]{% endif %}{% endblock %}
@@ -227,21 +295,9 @@ $(document).ready(function() {
                                             <th>{% trans "Owner" %}</th>
                                         </tr>
                                     </thead>
-                                    <tbody>
-                                        {% for ticket in tickets %}
-                                        <tr class="{{ ticket.get_priority_css_class }}">
-                                            <th><a href='{{ ticket.get_absolute_url }}'>{{ ticket.ticket }}</a></th>
-                                            <td><input type='checkbox' name='ticket_id' value='{{ ticket.id }}' class='ticket_multi_select' /></td>
-                                            <td>{{ ticket.priority }}</td>
-                                            <th><a href='{{ ticket.get_absolute_url }}'>{{ ticket.title }}</a></th>
-                                            <td>{{ ticket.queue }}</td>
-                                            <td>{{ ticket.get_status }}</td>
-                                            <td data-order='{{ ticket.created|date:"U" }}'><span title='{{ ticket.created|date:"r" }}'>{{ ticket.created|naturaltime }}</span></td>
-                                            <td data-order='{{ ticket.due_date|date:"U" }}'><span title='{{ ticket.due_date|date:"r" }}'>{{ ticket.due_date|naturaltime }}</span></td>
-                                            <td>{{ ticket.get_assigned_to }}</td>
-                                        </tr>
-                                        {% endfor %}
-                                    </tbody>
+                                    {% if not server_side %}
+                                    {% include 'helpdesk/ticket_list_table.html' %}
+                                    {% endif %}
                                 </table>
                             {% csrf_token %}
 

--- a/helpdesk/templates/helpdesk/ticket_list_table.html
+++ b/helpdesk/templates/helpdesk/ticket_list_table.html
@@ -1,0 +1,17 @@
+{% load i18n humanize %}
+
+<tbody>
+    {% for ticket in tickets %}
+    <tr class="{{ ticket.get_priority_css_class }}">
+        <th><a href='{{ ticket.get_absolute_url }}'>{{ ticket.ticket }}</a></th>
+        <td><input type='checkbox' name='ticket_id' value='{{ ticket.id }}' class='ticket_multi_select' /></td>
+        <td>{{ ticket.priority }}</td>
+        <th><a href='{{ ticket.get_absolute_url }}'>{{ ticket.title }}</a></th>
+        <td>{{ ticket.queue }}</td>
+        <td>{{ ticket.get_status }}</td>
+        <td data-order='{{ ticket.created|date:"U" }}'><span title='{{ ticket.created|date:"r" }}'>{{ ticket.created|naturaltime }}</span></td>
+        <td data-order='{{ ticket.due_date|date:"U" }}'><span title='{{ ticket.due_date|date:"r" }}'>{{ ticket.due_date|naturaltime }}</span></td>
+        <td>{{ ticket.get_assigned_to }}</td>
+    </tr>
+    {% endfor %}
+</tbody>

--- a/helpdesk/urls.py
+++ b/helpdesk/urls.py
@@ -141,6 +141,10 @@ urlpatterns = [
     url(r'^ignore/delete/(?P<id>[0-9]+)/$',
         staff.email_ignore_del,
         name='email_ignore_del'),
+
+    url(r'^datatables_ticket_list/$',
+        staff.datatables_ticket_list,
+        name="datatables_ticket_list"),
 ]
 
 urlpatterns += [

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ lxml
 simplejson
 pytz
 six
+djangorestframework
+django-model-utils


### PR DESCRIPTION
I've added serverside processing for datatables on the tickets_list.html page. I've made optional via a flag in settings.py. It is set to True by default. 

Datatables will do an ajax request to fetch the queryset after the page has loaded, which is why I'm using django's low level cache API to store it and and then retrieve it for datatables. 

This is my first major commit to github, I may have made mistakes - logical or syntactical. I have tested the feature, it worked well. Please let me know if there is a lack of documentation, comments or any other mistakes, I am happy to learn!

Searching is now different on the tables for date fields (created and due_date), because the naturaltime format is not stored on the DB, it is not possible to search it with that string. Instead, users will have to use "2018-10-4" as the search string to search for tickets created on October 4, 2018.