### PR TITLE
Forms' staff overriding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ docs/doctrees/*
 .project
 .pydevproject
 .directory
+.vscode
 
 # ignore demo attachments that user might have added
 helpdesk/attachments/

--- a/helpdesk/management/commands/get_email.py
+++ b/helpdesk/management/commands/get_email.py
@@ -401,10 +401,10 @@ def ticket_from_message(message, queue, logger):
         if ">" in mail.text:
             body = mail.find('body')
             try:
-              body = body.text
-              body = body.encode('ascii', errors='ignore')
+               body = body.text
+               body = body.encode('ascii', errors='ignore')
             except AttributeError:
-              body = ''
+               body = ''
         else:
             body = mail.text
 

--- a/helpdesk/management/commands/get_email.py
+++ b/helpdesk/management/commands/get_email.py
@@ -400,8 +400,11 @@ def ticket_from_message(message, queue, logger):
         mail = BeautifulSoup(part.get_payload(), "lxml")
         if ">" in mail.text:
             body = mail.find('body')
-            body = body.text
-            body = body.encode('ascii', errors='ignore')
+            try:
+              body = body.text
+              body = body.encode('ascii', errors='ignore')
+            except AttributeError:
+              body = ''
         else:
             body = mail.text
 

--- a/helpdesk/settings.py
+++ b/helpdesk/settings.py
@@ -131,6 +131,42 @@ HELPDESK_EMAIL_FALLBACK_LOCALE = getattr(settings, 'HELPDESK_EMAIL_FALLBACK_LOCA
 HELPDESK_CREATE_TICKET_HIDE_ASSIGNED_TO = getattr(
     settings, 'HELPDESK_CREATE_TICKET_HIDE_ASSIGNED_TO', False)
 
+#settings for override view/staff.py forms easily
+HELPDESK_FORM_TICKET = getattr(
+    settings,
+    'HELPDESK_FORM_TICKET', "helpdesk.forms.TicketForm")
+
+HELPDESK_FORM_USERSETTING = getattr(
+    settings,
+    "HELPDESK_FORM_USERSETTING", "helpdesk.forms.UserSettingsForm")
+
+HELPDESK_FORM_EMAIL_IGNORE = getattr(
+    settings,
+    "HELPDESK_FORM_EMAIL_IGNORE", "helpdesk.forms.EmailIgnoreForm")
+
+HELPDESK_FORM_EDIT_TICKET = getattr(
+    settings,
+    "HELPDESK_FORM_EDIT_TICKET", "helpdesk.forms.EditTicketForm")
+
+HELPDESK_FORM_TICKETCC = getattr(
+    settings,
+    "HELPDESK_FORM_TICKETCC", "helpdesk.forms.TicketCCForm")
+
+HELPDESK_FORM_TICKETCC_EMAIL = getattr(
+    settings,
+    "HELPDESK_FORM_TICKETCC_EMAIL", "helpdesk.forms.TicketCCEmailForm")
+
+HELPDESK_FORM_TICKETCC_USER = getattr(
+    settings,
+    "HELPDESK_FORM_TICKETCC_USER", "helpdesk.forms.TicketCCUserForm")
+
+HELPDESK_FORM_EDIT_FOLLOWUP = getattr(
+    settings,
+    "HELPDESK_FORM_EDIT_FOLLOWUP", "helpdesk.forms.EditFollowUpForm")
+
+HELPDESK_FORM_TICKET_DEPENDENCY = getattr(
+    settings,
+    "HELPDESK_FORM_TICKET_DEPENDENCY", "helpdesk.forms.TicketDependencyForm")
 
 #################
 # email options #

--- a/helpdesk/settings.py
+++ b/helpdesk/settings.py
@@ -81,6 +81,10 @@ HELPDESK_VIEW_A_TICKET_PUBLIC = getattr(settings, 'HELPDESK_VIEW_A_TICKET_PUBLIC
 HELPDESK_SUBMIT_A_TICKET_PUBLIC = getattr(settings, 'HELPDESK_SUBMIT_A_TICKET_PUBLIC', True)
 
 
+HELPDESK_FORM_TICKET_PUBLIC = getattr(
+    settings,
+    "HELPDESK_FORM_TICKET_PUBLIC", "helpdesk.forms.PublicTicketForm")
+
 ###################################
 # options for update_ticket views #
 ###################################

--- a/helpdesk/templates/helpdesk/create_ticket.html
+++ b/helpdesk/templates/helpdesk/create_ticket.html
@@ -57,11 +57,4 @@ $(document).on('change', ':file', function() {
                     <!-- /.panel -->
                 </div>
             </div>
-
-            <script>
-                $( function() {
-                    $( "#id_due_date" ).datepicker();
-                } );
-            </script>
-
 {% endblock %}

--- a/helpdesk/views/public.py
+++ b/helpdesk/views/public.py
@@ -21,9 +21,12 @@ from django.conf import settings
 
 from helpdesk import settings as helpdesk_settings
 from helpdesk.decorators import protect_view
-from helpdesk.forms import PublicTicketForm
 from helpdesk.lib import text_is_spam
 from helpdesk.models import Ticket, Queue, UserSettings, KBCategory
+from pydoc import locate
+
+
+PublicTicketForm = locate(helpdesk_settings.HELPDESK_FORM_TICKET_PUBLIC)
 
 
 @protect_view

--- a/helpdesk/views/staff.py
+++ b/helpdesk/views/staff.py
@@ -49,7 +49,6 @@ TicketDependencyForm = locate(helpdesk_settings.HELPDESK_FORM_TICKET_DEPENDENCY)
 
 User = get_user_model()
 
-
 if helpdesk_settings.HELPDESK_ALLOW_NON_STAFF_TICKET_UPDATE:
     # treat 'normal' users like 'staff'
     staff_member_required = user_passes_test(

--- a/helpdesk/views/staff.py
+++ b/helpdesk/views/staff.py
@@ -7,40 +7,45 @@ views/staff.py - The bulk of the application - provides most business logic and
                  renders all staff-facing views.
 """
 from __future__ import unicode_literals
-from datetime import date, datetime, timedelta
+
 import re
+from datetime import date, datetime, timedelta
+from pydoc import locate
 
 from django import VERSION as DJANGO_VERSION
+from django import forms
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import user_passes_test
-from django.urls import reverse
-from django.core.exceptions import ValidationError, PermissionDenied
+from django.core.exceptions import PermissionDenied, ValidationError
 from django.db import connection
 from django.db.models import Q
-from django.http import HttpResponseRedirect, Http404, HttpResponse
-from django.shortcuts import render, get_object_or_404
+from django.http import Http404, HttpResponse, HttpResponseRedirect
+from django.shortcuts import get_object_or_404, render
+from django.urls import reverse
+from django.utils import six, timezone
 from django.utils.dates import MONTHS_3
-from django.utils.translation import ugettext as _
 from django.utils.html import escape
-from django import forms
-from django.utils import timezone
+from django.utils.translation import ugettext as _
 
-from django.utils import six
-
-from helpdesk.forms import (
-    TicketForm, UserSettingsForm, EmailIgnoreForm, EditTicketForm, TicketCCForm,
-    TicketCCEmailForm, TicketCCUserForm, EditFollowUpForm, TicketDependencyForm
-)
-from helpdesk.lib import (
-    send_templated_mail, query_to_dict, apply_query, safe_template_context,
-    process_attachments, queue_template_context,
-)
-from helpdesk.models import (
-    Ticket, Queue, FollowUp, TicketChange, PreSetReply, Attachment, SavedSearch,
-    IgnoreEmail, TicketCC, TicketDependency,
-)
 from helpdesk import settings as helpdesk_settings
+from helpdesk.lib import (apply_query, process_attachments, query_to_dict,
+                          queue_template_context, safe_template_context,
+                          send_templated_mail)
+from helpdesk.models import (Attachment, FollowUp, IgnoreEmail, PreSetReply,
+                             Queue, SavedSearch, Ticket, TicketCC,
+                             TicketChange, TicketDependency)
+
+# Import form for override easily
+TicketForm = locate(helpdesk_settings.HELPDESK_FORM_TICKET)
+UserSettingsForm = locate(helpdesk_settings.HELPDESK_FORM_USERSETTING)
+EmailIgnoreForm = locate(helpdesk_settings.HELPDESK_FORM_EMAIL_IGNORE)
+EditTicketForm = locate(helpdesk_settings.HELPDESK_FORM_EDIT_TICKET)
+TicketCCForm = locate(helpdesk_settings.HELPDESK_FORM_TICKETCC)
+TicketCCEmailForm = locate(helpdesk_settings.HELPDESK_FORM_TICKETCC_EMAIL)
+TicketCCUserForm = locate(helpdesk_settings.HELPDESK_FORM_TICKETCC_USER)
+EditFollowUpForm = locate(helpdesk_settings.HELPDESK_FORM_EDIT_FOLLOWUP)
+TicketDependencyForm = locate(helpdesk_settings.HELPDESK_FORM_TICKET_DEPENDENCY)
 
 User = get_user_model()
 


### PR DESCRIPTION
Due form calling inside views into views/staff.py, it's difficult to override forms (for adding some special fields, create fieldsets, ....).
So it could be interesting to have a setting for this. I try this solution and works great. 