### PR TITLE
Set voted_by to read only in knowledge base admin

### DIFF
--- a/helpdesk/admin.py
+++ b/helpdesk/admin.py
@@ -51,6 +51,8 @@ class FollowUpAdmin(admin.ModelAdmin):
 @admin.register(KBItem)
 class KBItemAdmin(admin.ModelAdmin):
     list_display = ('category', 'title', 'last_updated',)
+    readonly_fields = ('voted_by',)
+
     list_display_links = ('title',)
 
 


### PR DESCRIPTION
Currently, the admin times out when loading thousands of users (in order to let you select which users voted). It makes more sense to make this read-only.