### PR TITLE
Add pencil buttons to ticket view for easier assignment and priority …

### DIFF
--- a/helpdesk/templates/helpdesk/ticket.html
+++ b/helpdesk/templates/helpdesk/ticket.html
@@ -168,7 +168,7 @@
 
         <dt><label for='id_priority'>{% trans "Priority" %}</label></dt>
         <dd><select id='id_priority' name='priority'>{% for p in priorities %}<option value='{{ p.0 }}'{% ifequal p.0 ticket.priority %} selected='selected'{% endifequal %}>{{ p.1 }}</option>{% endfor %}</select></dd>
-        
+
         <dt><label for='id_due_date'>{% trans "Due on" %}</label></dt>
         <dd>{{ form.due_date }}</dd>
 
@@ -215,8 +215,7 @@ $( function() {
 <script type='text/javascript' language='javascript'>
 $(document).ready(function() {
     $("#ShowFurtherEditOptions").click(function() {
-        $("#FurtherEditOptions").fadeIn();
-        $("#ShowFurtherOptPara").hide();
+        $("#FurtherEditOptions").toggle();
         return false;
     });
 

--- a/helpdesk/templates/helpdesk/ticket_desc_table.html
+++ b/helpdesk/templates/helpdesk/ticket_desc_table.html
@@ -37,7 +37,11 @@
                     </tr>{% endif %}
                     <tr>
                         <th>{% trans "Due Date" %}</th>
-                        <td>{{ ticket.due_date|date:"r" }} ({{ ticket.due_date|naturaltime }})</td>
+                        <td>{{ ticket.due_date|date:"r" }} ({{ ticket.due_date|naturaltime }})
+                        <strong>
+                           <a href='#FurtherEditOptions'><button type="button" class="btn btn-sm btn-warning float-right" onclick="$('#FurtherEditOptions').fadeIn()"><i class="fas fa-pencil-alt"></i></button></a>
+                        </strong>
+                        </td>
                     </tr>
                     <tr>
                         <th>{% trans "Submitted On" %}</th>
@@ -45,17 +49,28 @@
                     </tr>
                     <tr>
                         <th>{% trans "Assigned To" %}</th>
-                        <td>{{ ticket.get_assigned_to }}{% ifequal ticket.get_assigned_to _('Unassigned') %} <strong><a href='?take'><button type="button" class="btn btn-primary btn-sm"><i class="fas fa-hand-paper"></i>&nbsp;{% trans "Take" %}</button></a></strong>{% endifequal %}</td>
+                        <td>{{ ticket.get_assigned_to }}{% ifequal ticket.get_assigned_to _('Unassigned') %} <strong>
+                           <a href='?take'><button type="button" class="btn btn-primary btn-sm"><i class="fas fa-hand-paper"></i>&nbsp;{% trans "Take" %}</button></a>
+                        </strong>{% endifequal %}
+                        <strong>
+                           <a href='#FurtherEditOptions'><button type="button" class="btn btn-sm btn-warning float-right" onclick="$('#FurtherEditOptions').fadeIn()"><i class="fas fa-pencil-alt"></i></button></a>
+                        </strong>
+                        </td>
                     </tr>
                     <tr>
                         <th>{% trans "Submitter E-Mail" %}</th>
                         <td>{{ ticket.submitter_email }}
                         {% if user.is_superuser %} {% if submitter_userprofile_url %}<strong><a href='{{submitter_userprofile_url}}'><button type="button" class="btn btn-primary btn-sm"><i class="fas fa-address-book"></i>&nbsp;{% trans "Profile" %}</button></a></strong>{% endif %}
-                        <strong><a href='{% url 'helpdesk:email_ignore_add' %}?email={{ ticket.submitter_email }}'><button type="button" class="btn btn-warning btn-sm"><i class="fas fa-eye-slash"></i>&nbsp;{% trans "Ignore" %}</button></a></strong>{% endif %}</td>
+                        <strong><a href='{% url 'helpdesk:email_ignore_add' %}?email={{ ticket.submitter_email }}'><button type="button" class="btn btn-warning btn-sm"><i class="fas fa-eye-slash"></i>&nbsp;{% trans "Ignore" %}</button></a></strong>{% endif %}
+                        </td>
                     </tr>
                     <tr>
                         <th>{% trans "Priority" %}</th>
-                        <td>{{ ticket.get_priority_display }}</td>
+                        <td>{{ ticket.get_priority_display }}
+                        <strong>
+                           <a href='#FurtherEditOptions'><button type="button" class="btn btn-sm btn-warning float-right" onclick="$('#FurtherEditOptions').fadeIn()"><i class="fas fa-pencil-alt"></i></button></a>
+                        </strong>
+                        </td>
                     </tr>
                     <tr>
                         <th>{% trans "Copies To" %}</th>


### PR DESCRIPTION
…setting

![assign](https://user-images.githubusercontent.com/1391608/52168498-68646e00-272b-11e9-9846-d063f9878ff9.png)

Right now the buttons just jump down to the bottom section, which isn't very modern (modern web design would make the field transform into an editable one) but I actually find it to be good, because then you're down right next to the submit button when preforming a quick change.