### PR TITLE
Display only queues for the logged-in user

### DIFF
--- a/helpdesk/tests/test_ticket_submission.py
+++ b/helpdesk/tests/test_ticket_submission.py
@@ -70,6 +70,8 @@ class TicketBasicsTestCase(TestCase):
         self.assertEqual(email_count + 3, len(mail.outbox))
 
     def test_create_ticket_private(self):
+        from helpdesk import settings as helpdesk_settings
+        helpdesk_settings.HELPDESK_ENABLE_PER_QUEUE_STAFF_PERMISSION = True
         email_count = len(mail.outbox)
         post_data = {
             'title': 'Private ticket test',


### PR DESCRIPTION
In the submission form (public and staff), display only queues, which should be available for the logged-in user only.