### PR TITLE
AttributeError: 'Command' object has no attribute 'option_list'

### DIFF
--- a/helpdesk/management/commands/escalate_tickets.py
+++ b/helpdesk/management/commands/escalate_tickets.py
@@ -32,7 +32,7 @@ class Command(BaseCommand):
     def __init__(self):
         BaseCommand.__init__(self)
 
-        self.option_list += (
+        self.option_list = (
             make_option(
                 '--queues',
                 help='Queues to include (default: all). Use queue slugs'),


### PR DESCRIPTION
There is a bug in the command in which option_list doesn't exist and thus, cannot be added to.