### PR TITLE
fix date picker format

### DIFF
--- a/helpdesk/templates/helpdesk/create_ticket.html
+++ b/helpdesk/templates/helpdesk/create_ticket.html
@@ -60,7 +60,7 @@ $(document).on('change', ':file', function() {
 
             <script>
                 $( function() {
-                    $( "#id_due_date" ).datepicker();
+			$( "#id_due_date" ).datepicker({dateFormat: 'yy-mm-dd'});
                 } );
             </script>
 

--- a/helpdesk/templates/helpdesk/edit_ticket.html
+++ b/helpdesk/templates/helpdesk/edit_ticket.html
@@ -40,7 +40,7 @@
 
 <script>
 $( function() {
-    $( "#id_due_date" ).datepicker();
+	$( "#id_due_date" ).datepicker({dateFormat: 'yy-mm-dd'});
 } );
 </script>
 

--- a/helpdesk/templates/helpdesk/ticket.html
+++ b/helpdesk/templates/helpdesk/ticket.html
@@ -250,7 +250,7 @@ $(document).on('change', ':file', function() {
 
 <script>
 $( function() {
-    $( "#id_due_date" ).datepicker();
+	$( "#id_due_date" ).datepicker({dateFormat: 'yy-mm-dd'});
 } );
 </script>
 


### PR DESCRIPTION
When trying to create new ticket or edit existing ticket with Due date filled in, `form.is_valid()` in `create_ticket()` function returns `False`

This seems to be due to jQuery returns `dd/mm/YYYY` format back. Setting `dateFormat` to `yy-mm-dd` seems to solve the issue