### PR TITLE
Error not raised when user change the HELPDESK_PUBLIC_TICKET_QUEUE in…

### DIFF
--- a/helpdesk/views/public.py
+++ b/helpdesk/views/public.py
@@ -67,11 +67,8 @@ def homepage(request):
 
         # add pre-defined data for public ticket
         if hasattr(settings, 'HELPDESK_PUBLIC_TICKET_QUEUE'):
-            # get the requested queue; return an error if queue not found
-            try:
-                queue = Queue.objects.get(slug=settings.HELPDESK_PUBLIC_TICKET_QUEUE)
-            except Queue.DoesNotExist:
-                return HttpResponse(status=500)
+            slug=settings.HELPDESK_PUBLIC_TICKET_QUEUE
+            queue = Queue.objects.get(slug=slug)
         if hasattr(settings, 'HELPDESK_PUBLIC_TICKET_PRIORITY'):
             initial_data['priority'] = settings.HELPDESK_PUBLIC_TICKET_PRIORITY
         if hasattr(settings, 'HELPDESK_PUBLIC_TICKET_DUE_DATE'):


### PR DESCRIPTION
… the admin.

Please do not return blank HttpResponse(status=500) it is a nightmare to locate/debug when a user change the list name in the admin.

Either let it raise its exception or give it a default value to display the form.

I separated the slug so it displays its values in the logger.