### PR TITLE
Resize too big images

### DIFF
--- a/helpdesk/static/helpdesk/helpdesk-extend.css
+++ b/helpdesk/static/helpdesk/helpdesk-extend.css
@@ -76,3 +76,7 @@ Add your custom styles here
 }
 #helpdesk-body {padding-top: 100px;}
 img.brand {padding-right: 30px;}
+
+div.card-body img {
+	max-width: 900px;
+}


### PR DESCRIPTION
Some too big images, if they are animated GIF's and overflow the page size, are not animated any more.

We use animated GIFs for the demonstration how to do things in the knowledge base. This fix makes the GIFs move, even if they are big.