### PR TITLE
Fix command rundemo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,8 +83,8 @@ readme:
 #: demo - Setup demo project using Python3.
 .PHONY: demo
 demo:
-	$(PIP) install -e .
-	$(PIP) install -e demo
+	$(PIP) install -e . --user
+	$(PIP) install -e demo --user
 	demodesk migrate --noinput
 	# Create superuser; user will be prompted to manually set a password
 	# When you get a prompt, enter a password of your choosing.

--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ resides in the `demo/` top-level folder.
 It's likely that you can start up a demo project server by running
 only the command::
 
-    sudo make rundemo
+    make rundemo
 
 then pointing your web browser at `localhost:8080`.
 

--- a/demo/README.rst
+++ b/demo/README.rst
@@ -28,7 +28,7 @@ Ideally, you'd use a virtualenv instead
 To use your system directory, from the top-level
 django-helpdesk directory, simply run:
 
-    sudo make rundemo
+    make rundemo
 
 Once the console gives a prompt that the HTTP
 server is listening, open your web browser


### PR DESCRIPTION
We get an error if we run the command  ```sudo make rundemo```

Here is the error in the image : 

![error](https://user-images.githubusercontent.com/2384094/54395170-56bda100-46af-11e9-806d-a5a381f6c7d4.png)
