### PR TITLE
Fix error 500 public homepage when objects kb_category

### DIFF
--- a/helpdesk/tests/test_navigation.py
+++ b/helpdesk/tests/test_navigation.py
@@ -2,6 +2,7 @@
 from django.urls import reverse
 from django.test import TestCase
 
+from helpdesk.models import KBCategory
 from helpdesk.tests.helpers import get_staff_user, reload_urlconf
 
 
@@ -36,3 +37,11 @@ class TestKBDisabled(TestCase):
                 raise
         else:
             self.assertEqual(response.status_code, 200)
+
+    def test_public_homepage_with_kb_category(self):
+        KBCategory.objects.create(title="KB Cat 1",
+                                  slug="kbcat1",
+                                  description="Some category of KB info")
+        response = self.client.get(reverse('helpdesk:home'))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'helpdesk/public_homepage.html')

--- a/helpdesk/views/public.py
+++ b/helpdesk/views/public.py
@@ -87,7 +87,10 @@ def homepage(request):
         form.fields['queue'].choices = [('', '--------')] + [
             (q.id, q.title) for q in Queue.objects.filter(allow_public_submission=True)]
 
-    knowledgebase_categories = KBCategory.objects.all()
+    knowledgebase_categories = None
+
+    if helpdesk_settings.HELPDESK_KB_ENABLED:
+        knowledgebase_categories = KBCategory.objects.all()
 
     return render(request, 'helpdesk/public_homepage.html', {
         'form': form,


### PR DESCRIPTION
If in your database you have KBCategory objects and you define the parameter ``HELPDESK_KB_ENABLED = False`` you get a 500 in the public_homepage view.