### PR TITLE
add space to heading of kb item

### DIFF
--- a/helpdesk/templates/helpdesk/kb_item.html
+++ b/helpdesk/templates/helpdesk/kb_item.html
@@ -11,7 +11,7 @@
 {% endblock %}
 
 {% block helpdesk_body %}
-<h2>{% trans 'Knowledgebase' %}:{% blocktrans with item.title as item %}{{ item }}{% endblocktrans %}</h2>
+<h2>{% trans 'Knowledgebase' %}: {% blocktrans with item.title as item %}{{ item }}{% endblocktrans %}</h2>
 
 <div class="card mb-3">
     <div class="card-header">


### PR DESCRIPTION
Missing space in knowledge base item heading 