### PR TITLE
display time spent only when user is_staff

### DIFF
--- a/helpdesk/templates/helpdesk/ticket.html
+++ b/helpdesk/templates/helpdesk/ticket.html
@@ -158,10 +158,12 @@
         <dd class='form_help_text'>{% trans "If this is public, the submitter will be e-mailed your comment or resolution." %}</dd>
         {% endif %}
 
+        {% if user.is_staff %}
         <dt>
             <label for='id_time_spent'>{% trans "Time spent" %}</label> <span class='form_optional'>{% trans "(Optional)" %}</span>
         </dt>
         <dd><input name='time_spent' type="time" /></dd>
+        {% endif %}
     </dl>
 
 <p id='ShowFurtherOptPara'><button class="btn btn-warning btn-sm" id='ShowFurtherEditOptions'>{% trans "Change Further Details &raquo;" %}</button></p>


### PR DESCRIPTION
When ticket is updated, display `time_spent input` only when `user.is_staff`