### PR TITLE
Support for custom login by setting LOGIN_URL

### DIFF
--- a/helpdesk/tests/test_login.py
+++ b/helpdesk/tests/test_login.py
@@ -35,3 +35,11 @@ class TestLoginRedirect(TestCase):
         """Test that default login is used when LOGIN_URL is None"""
         response = self.client.get(reverse('helpdesk:login'))
         self.assertTemplateUsed(response, 'helpdesk/registration/login.html')
+
+    @override_settings(LOGIN_URL='admin:login', SITE_ID=1)
+    def test_custom_login_view_with_name(self):
+        """Test that LOGIN_URL can be a view name"""
+        response = self.client.get(reverse('helpdesk:login'))
+        home_url = reverse('helpdesk:home')
+        expected = reverse('admin:login') + "?next=" + home_url
+        self.assertRedirects(response, expected)

--- a/helpdesk/tests/test_login.py
+++ b/helpdesk/tests/test_login.py
@@ -1,0 +1,37 @@
+from django.test import TestCase, override_settings
+from django.urls import reverse
+
+
+class TestLoginRedirect(TestCase):
+
+    @override_settings(LOGIN_URL='/custom/login/')
+    def test_custom_login_view_with_url(self):
+        """Test login redirect when LOGIN_URL is set to custom url"""
+        response = self.client.get(reverse('helpdesk:login'))
+        # We expect that that helpdesk:home url is passed as next parameter in
+        # the redirect url, so that the custom login can redirect the browser
+        # back to helpdesk after the login.
+        home_url = reverse('helpdesk:home')
+        expected = '/custom/login/?next={}'.format(home_url)
+        self.assertRedirects(response, expected, fetch_redirect_response=False)
+
+    @override_settings(LOGIN_URL='/custom/login/')
+    def test_custom_login_next_param(self):
+        """Test that the next url parameter is correctly relayed to custom login"""
+        next_param = "/redirect/back"
+        url = reverse('helpdesk:login') + "?next=" + next_param
+        response = self.client.get(url)
+        expected = '/custom/login/?next={}'.format(next_param)
+        self.assertRedirects(response, expected, fetch_redirect_response=False)
+
+    @override_settings(LOGIN_URL='helpdesk:login', SITE_ID=1)
+    def test_default_login_view(self):
+        """Test that default login is used when LOGIN_URL is helpdesk:login"""
+        response = self.client.get(reverse('helpdesk:login'))
+        self.assertTemplateUsed(response, 'helpdesk/registration/login.html')
+
+    @override_settings(LOGIN_URL=None, SITE_ID=1)
+    def test_login_url_none(self):
+        """Test that default login is used when LOGIN_URL is None"""
+        response = self.client.get(reverse('helpdesk:login'))
+        self.assertTemplateUsed(response, 'helpdesk/registration/login.html')

--- a/helpdesk/tests/urls.py
+++ b/helpdesk/tests/urls.py
@@ -1,5 +1,7 @@
 from django.conf.urls import include, url
+from django.contrib import admin
 
 urlpatterns = [
     url(r'^helpdesk/', include('helpdesk.urls', namespace='helpdesk')),
+    url(r'^admin/', admin.site.urls),
 ]

--- a/helpdesk/urls.py
+++ b/helpdesk/urls.py
@@ -13,7 +13,7 @@ from django.contrib.auth import views as auth_views
 from django.views.generic import TemplateView
 
 from helpdesk import settings as helpdesk_settings
-from helpdesk.views import feeds, staff, public, kb
+from helpdesk.views import feeds, staff, public, kb, login
 
 
 class DirectTemplateView(TemplateView):
@@ -185,8 +185,7 @@ urlpatterns += [
 
 urlpatterns += [
     url(r'^login/$',
-        auth_views.LoginView.as_view(
-            template_name='helpdesk/registration/login.html'),
+        login.login,
         name='login'),
 
     url(r'^logout/$',

--- a/helpdesk/views/login.py
+++ b/helpdesk/views/login.py
@@ -1,0 +1,21 @@
+from django.conf import settings
+from django.contrib.auth import views as auth_views
+from django.contrib.auth.views import redirect_to_login
+from django.shortcuts import resolve_url
+
+
+default_login_view = auth_views.LoginView.as_view(
+        template_name='helpdesk/registration/login.html')
+
+
+def login(request):
+    login_url = settings.LOGIN_URL
+    # Prevent redirect loop by checking that LOGIN_URL is not this view's name
+    if login_url and login_url != request.resolver_match.view_name:
+        if 'next' in request.GET:
+            return_to = request.GET['next']
+        else:
+            return_to = resolve_url('helpdesk:home')
+        return redirect_to_login(return_to, login_url)
+    else:
+        return default_login_view(request)


### PR DESCRIPTION
Hi, we are planning to use django-helpdesk in our small web platform that uses [mozilla-django-oidc](https://github.com/mozilla/mozilla-django-oidc) for user authentication.

I read though this project's documentation and in section [Adding To Your Django Project](https://django-helpdesk.readthedocs.io/en/0.2.x/install.html#adding-to-your-django-project) section 8, it says that you can handle logins with custom view by setting `LOGIN_URL` to that view's url. I don't think that setting is working correctly. It seems that django-helpdesk ignores that setting completely. Then I found this issue https://github.com/django-helpdesk/django-helpdesk/issues/246, where another user had similar problems.

This is a possible fix for the issue.