### PR TITLE
Fix ticket search, when there are multiple custom fields

### DIFF
--- a/helpdesk/lib.py
+++ b/helpdesk/lib.py
@@ -197,7 +197,8 @@ def apply_query(queryset, params):
             Q(ticketcustomfieldvalue__value__icontains=search)
         )
 
-        queryset = queryset.filter(qset)
+        # Distinct works, when there are multiple custom fields
+        queryset = queryset.filter(qset).distinct()
 
     sorting = params.get('sorting', None)
     if sorting:


### PR DESCRIPTION
Hello, search in custom field, implemented in last version (0.2.17) working bad, when there are multiple custom fields (more then one).
Search result contains multiple rows for each ticket. (We have 3 rows for each ticket. Because we have 3 custom fields enabled)
I've just added distinct grouping after resulting query. Then we have one row per ticket.

Query from this commit
https://github.com/django-helpdesk/django-helpdesk/commit/45854e44a7b1f09a51dd9608a2cc527f9ddd34cf
looks like:
select helpdesk_ticket.id FROM
 "helpdesk_ticket" INNER JOIN "helpdesk_queue" ON 
 ("helpdesk_ticket"."queue_id" = "helpdesk_queue"."id") LEFT OUTER JOIN 
 "helpdesk_ticketcustomfieldvalue" ON ("helpdesk_ticket"."id" = 
 "helpdesk_ticketcustomfieldvalue"."ticket_id");

