### PR TITLE
fix<ticket-search>: avoid exception of using function get_tickets_in_queues as property

### DIFF
--- a/helpdesk/views/staff.py
+++ b/helpdesk/views/staff.py
@@ -839,7 +839,7 @@ def ticket_list(request):
 
         if filter:
             try:
-                ticket = huser.get_tickets_in_queues.get(**filter)
+                ticket = huser.get_tickets_in_queues().get(**filter)
                 return HttpResponseRedirect(ticket.staff_url)
             except Ticket.DoesNotExist:
                 # Go on to standard keyword searching


### PR DESCRIPTION
haven't covered it by tests, sorry. seems useful anyway, fixed a bug we had which you get when you just enter some digits to the search field.