### PR TITLE
Fill followup user field if authenticated user submits ticket

### DIFF
--- a/helpdesk/forms.py
+++ b/helpdesk/forms.py
@@ -318,7 +318,7 @@ class TicketForm(AbstractTicketForm):
         super(TicketForm, self).__init__(*args, **kwargs)
         self._add_form_custom_fields()
 
-    def save(self, user=None):
+    def save(self, user):
         """
         Writes and returns a Ticket() object
         """
@@ -378,7 +378,7 @@ class PublicTicketForm(AbstractTicketForm):
 
         self._add_form_custom_fields(False)
 
-    def save(self):
+    def save(self, user):
         """
         Writes and returns a Ticket() object
         """
@@ -389,7 +389,8 @@ class PublicTicketForm(AbstractTicketForm):
 
         self._create_custom_fields(ticket)
 
-        followup = self._create_follow_up(ticket, title=_('Ticket Opened Via Web'))
+        followup = self._create_follow_up(
+            ticket, title=_('Ticket Opened Via Web'), user=user)
         followup.save()
 
         files = self._attach_files_to_follow_up(followup)

--- a/helpdesk/tests/test_ticket_submission.py
+++ b/helpdesk/tests/test_ticket_submission.py
@@ -1,5 +1,6 @@
 from helpdesk.models import Queue, CustomField, Ticket
 from django.test import TestCase
+from django.contrib.auth import get_user_model
 from django.core import mail
 from django.test.client import Client
 from django.urls import reverse
@@ -31,6 +32,10 @@ class TicketBasicsTestCase(TestCase):
             'title': 'Test Ticket',
             'description': 'Some Test Ticket',
         }
+
+        self.user = get_user_model().objects.create(
+            username='User_1',
+        )
 
         self.client = Client()
 
@@ -68,6 +73,45 @@ class TicketBasicsTestCase(TestCase):
 
         # Ensure submitter, new-queue + update-queue were all emailed.
         self.assertEqual(email_count + 3, len(mail.outbox))
+
+        ticket = Ticket.objects.last()
+        self.assertEqual(ticket.followup_set.count(), 1)
+        # Follow up is anonymous
+        self.assertIsNone(ticket.followup_set.first().user)
+
+    def test_create_ticket_authorized(self):
+        email_count = len(mail.outbox)
+        self.client.force_login(self.user)
+
+        response = self.client.get(reverse('helpdesk:home'))
+        self.assertEqual(response.status_code, 200)
+
+        post_data = {
+            'title': 'Test ticket title',
+            'queue': self.queue_public.id,
+            'submitter_email': 'ticket1.submitter@example.com',
+            'body': 'Test ticket body',
+            'priority': 3,
+        }
+
+        response = self.client.post(reverse('helpdesk:home'), post_data, follow=True)
+        last_redirect = response.redirect_chain[-1]
+        last_redirect_url = last_redirect[0]
+        # last_redirect_status = last_redirect[1]
+
+        # Ensure we landed on the "View" page.
+        # Django 1.9 compatible way of testing this
+        # https://docs.djangoproject.com/en/1.9/releases/1.9/#http-redirects-no-longer-forced-to-absolute-uris
+        urlparts = urlparse(last_redirect_url)
+        self.assertEqual(urlparts.path, reverse('helpdesk:public_view'))
+
+        # Ensure submitter, new-queue + update-queue were all emailed.
+        self.assertEqual(email_count + 3, len(mail.outbox))
+
+        ticket = Ticket.objects.last()
+        self.assertEqual(ticket.followup_set.count(), 1)
+        # Follow up is for registered user
+        self.assertEqual(ticket.followup_set.first().user, self.user)
 
     def test_create_ticket_private(self):
         email_count = len(mail.outbox)

--- a/helpdesk/views/public.py
+++ b/helpdesk/views/public.py
@@ -48,7 +48,8 @@ def homepage(request):
                 # This submission is spam. Let's not save it.
                 return render(request, template_name='helpdesk/public_spam.html')
             else:
-                ticket = form.save()
+                ticket = form.save(
+                    user=request.user if request.user.is_authenticated else None)
                 try:
                     return HttpResponseRedirect('%s?ticket=%s&email=%s' % (
                         reverse('helpdesk:public_view'),


### PR DESCRIPTION
Currently follow up field is not filled even if authenticated user submits ticket. So it's impossible to generate user's ticket list.