### PR TITLE
Optionally hide Saved Queries from Frontend

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -81,15 +81,19 @@ These changes are visible throughout django-helpdesk
 - **HELPDESK_EMAIL_FALLBACK_LOCALE** Fallback locale for templated emails when queue locale not found
 
   **Default:** ``HELPDESK_EMAIL_FALLBACK_LOCALE = "en"``
-  
+
 - **QUEUE_EMAIL_BOX_UPDATE_ONLY** Only process mail with a valid tracking ID; all other mail will be ignored instead of creating a new ticket.
 
   **Default:** ``QUEUE_EMAIL_BOX_UPDATE_ONLY = False``
-  
+
 - **HELPDESK_ANON_ACCESS_RAISES_404** If True, redirects user to a 404 page when attempting to reach ticket pages while not logged in, rather than redirecting to a login screen.
 
   **Default:** ``HELPDESK_ANON_ACCESS_RAISES_404 = False``
-  
+
+- **HELPDESK_HIDE_SAVED_QUERIES** Hide "Saved queries" tools from frontend
+
+  **Default:** ``HELPDESK_HIDE_SAVED_QUERIES = False``
+
 Options shown on public pages
 -----------------------------
 

--- a/helpdesk/settings.py
+++ b/helpdesk/settings.py
@@ -121,6 +121,7 @@ if HELPDESK_EMAIL_SUBJECT_TEMPLATE.find("ticket.ticket") < 0:
 # default fallback locale when queue locale not found
 HELPDESK_EMAIL_FALLBACK_LOCALE = getattr(settings, 'HELPDESK_EMAIL_FALLBACK_LOCALE', 'en')
 
+HELPDESK_HIDE_SAVED_QUERIES = getattr(settings, 'HELPDESK_HIDE_SAVED_QUERIES', False)
 
 ########################################
 # options for staff.create_ticket view #

--- a/helpdesk/templates/helpdesk/navigation-sidebar.html
+++ b/helpdesk/templates/helpdesk/navigation-sidebar.html
@@ -16,10 +16,12 @@
           </a>
         </li>
         <li class="nav-item dropdown">
+          {% if not helpdesk_settings.HELPDESK_HIDE_SAVED_QUERIES %}
           <a class="nav-link dropdown-toggle" href="#" id="ticketsDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             <i class="fas fa-fw fa-search"></i>
             <span>{% trans "Saved Queries" %}</span>
           </a>
+          {% endif %}
           <div class="dropdown-menu" aria-labelledby="ticketsDropdown">
             {% if user_saved_queries_ %}
             {% for q in user_saved_queries_ %}

--- a/helpdesk/templates/helpdesk/ticket_list.html
+++ b/helpdesk/templates/helpdesk/ticket_list.html
@@ -34,7 +34,7 @@
     <div class="card-header">
     <ul class="nav nav-tabs">
         <li class="nav-item" style="width: 200px;">
-            {% trans "Query Results" %}: 
+            {% trans "Query Results" %}:
         </li>
         <li class="nav-item"">
             <a class="nav-link active" href="#datatabletabcontents" id="datatabletabcontents-tab"  data-toggle="tab" role="tab" aria-controls="datatabletabcontents" aria-selected=true>
@@ -145,7 +145,8 @@
 </div>
 <!-- /.panel -->
 
-<div class="card mb-3">
+
+<div class="card mb-3"{% if helpdesk_settings.HELPDESK_HIDE_SAVED_QUERIES %} style="display: none;"{% endif %}>
     <div class="card-header">
         <i class="fas fa-hand-pointer"></i>
         {% trans "Query Selection" %}


### PR DESCRIPTION
At the beginning, you have to manage a few tickets, and need to familiarise with the workflow.
In that context, Saved Queries are useless, and rather intimidating 