### PR TITLE
fix for unpack requires a string argument of length 44 on py27

### DIFF
--- a/quicktest.py
+++ b/quicktest.py
@@ -68,6 +68,7 @@ class QuickDjangoTest(object):
 
         settings.configure(
             DEBUG=True,
+            TIME_ZONE='UTC',
             DATABASES={
                 'default': {
                     'ENGINE': 'django.db.backends.sqlite3',


### PR DESCRIPTION
Fix for failing test on travis w/ py27 re pytz