### PR TITLE
"Overview" not translated in templates

### DIFF
--- a/helpdesk/templates/helpdesk/dashboard.html
+++ b/helpdesk/templates/helpdesk/dashboard.html
@@ -6,7 +6,7 @@
 <li class="breadcrumb-item">
     <a href="#">Dashboard</a>
 </li>
-<li class="breadcrumb-item active">Overview</li>
+<li class="breadcrumb-item active">{% trans "Overview" %}</li>
 {% endblock %}
 
 {% block helpdesk_body %}

--- a/helpdesk/templates/helpdesk/kb_index.html
+++ b/helpdesk/templates/helpdesk/kb_index.html
@@ -6,7 +6,7 @@
 <li class="breadcrumb-item">
     <a href="{% url 'helpdesk:kb_index' %}">{% trans "Knowledgebase" %}</a>
 </li>
-<li class="breadcrumb-item active">Overview</li>
+<li class="breadcrumb-item active">{% trans "Overview" %}</li>
 {% endblock %}
 
 {% block helpdesk_body %}

--- a/helpdesk/templates/helpdesk/ticket_list.html
+++ b/helpdesk/templates/helpdesk/ticket_list.html
@@ -22,7 +22,7 @@
 <li class="breadcrumb-item">{% trans "Saved Query" %}</li>
 <li class="breadcrumb-item active">{{ saved_query.title }}</li>
 {% else %}
-<li class="breadcrumb-item active">Overview</li>
+<li class="breadcrumb-item active">{% trans "Overview" %}</li>
 {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
Fixed "Overview" to use translation in templates dashboard.html, kb_index.html and ticket_list.html