### PR TITLE
Feature/dashboard pagination

### DIFF
--- a/helpdesk/templates/helpdesk/dashboard.html
+++ b/helpdesk/templates/helpdesk/dashboard.html
@@ -16,18 +16,21 @@
 
 {% if all_tickets_reported_by_current_user %}
 {% trans "All Tickets submitted by you" as ticket_list_caption %}
-{% include 'helpdesk/include/tickets.html' with ticket_list=all_tickets_reported_by_current_user ticket_list_empty_message="" %}
+{% trans "atrbcu_page" as page_var}
+{% include 'helpdesk/include/tickets.html' with ticket_list=all_tickets_reported_by_current_user ticket_list_empty_message="" page_var=page_var %}
 {% endif %}
 
 {% trans "Open Tickets assigned to you (you are working on this ticket)" as ticket_list_caption %}
 {% trans "You have no tickets assigned to you." as no_assigned_tickets %}
-{% include 'helpdesk/include/tickets.html' with ticket_list=user_tickets ticket_list_empty_message=no_assigned_tickets %}
+{% trans "ut_page" as page_var}
+{% include 'helpdesk/include/tickets.html' with ticket_list=user_tickets ticket_list_empty_message=no_assigned_tickets page_var=page_var %}
 
 {% include 'helpdesk/include/unassigned.html' %}
 
 {% if user_tickets_closed_resolved %}
 {% trans "Closed & resolved Tickets you used to work on" as ticket_list_caption %}
-{% include 'helpdesk/include/tickets.html' with ticket_list=user_tickets_closed_resolved ticket_list_empty_message="" %}
+{% trans "utcr_page" as page_var}
+{% include 'helpdesk/include/tickets.html' with ticket_list=user_tickets_closed_resolved ticket_list_empty_message="" page_var=page_var %}
 {% endif %}
 
 {% endblock %}

--- a/helpdesk/templates/helpdesk/dashboard.html
+++ b/helpdesk/templates/helpdesk/dashboard.html
@@ -16,20 +16,20 @@
 
 {% if all_tickets_reported_by_current_user %}
 {% trans "All Tickets submitted by you" as ticket_list_caption %}
-{% trans "atrbcu_page" as page_var}
+{% trans "atrbcu_page" as page_var %}
 {% include 'helpdesk/include/tickets.html' with ticket_list=all_tickets_reported_by_current_user ticket_list_empty_message="" page_var=page_var %}
 {% endif %}
 
 {% trans "Open Tickets assigned to you (you are working on this ticket)" as ticket_list_caption %}
 {% trans "You have no tickets assigned to you." as no_assigned_tickets %}
-{% trans "ut_page" as page_var}
+{% trans "ut_page" as page_var %}
 {% include 'helpdesk/include/tickets.html' with ticket_list=user_tickets ticket_list_empty_message=no_assigned_tickets page_var=page_var %}
 
 {% include 'helpdesk/include/unassigned.html' %}
 
 {% if user_tickets_closed_resolved %}
 {% trans "Closed & resolved Tickets you used to work on" as ticket_list_caption %}
-{% trans "utcr_page" as page_var}
+{% trans "utcr_page" as page_var %}
 {% include 'helpdesk/include/tickets.html' with ticket_list=user_tickets_closed_resolved ticket_list_empty_message="" page_var=page_var %}
 {% endif %}
 

--- a/helpdesk/templates/helpdesk/include/tickets.html
+++ b/helpdesk/templates/helpdesk/include/tickets.html
@@ -37,6 +37,27 @@
                                 </table>
                             </div>
                             <!-- /.table-responsive -->
+                            {% if ticket_list.has_other_pages %}
+                                <ul class="pagination">
+                                    {% if ticket_list.has_previous %}
+                                        <li><a href="?{{ page_var }}={{ ticket_list.previous_page_number }}">&laquo;</a></li>
+                                    {% else %}
+                                        <li class="disabled"><span>&laquo;</span></li>
+                                    {% endif %}
+                                    {% for i in ticket_list.paginator.page_range %}
+                                        {% if ticket_list.number == i %}
+                                            <li class="active"><span>{{ i }} <span class="sr-only">(current)</span></span></li>
+                                        {% else %}
+                                            <li><a href="?{{ page_var }}={{ i }}">{{ i }}</a></li>
+                                        {% endif %}
+                                    {% endfor %}
+                                    {% if ticket_list.has_next %}
+                                        <li><a href="?{{ page_var }}={{ ticket_list.next_page_number }}">&raquo;</a></li>
+                                    {% else %}
+                                        <li class="disabled"><span>&raquo;</span></li>
+                                    {% endif %}
+                                </ul>
+                            {% endif %}
                         </div>
                         <!-- /.panel-body -->
                     </div>

--- a/helpdesk/templates/helpdesk/include/tickets.html
+++ b/helpdesk/templates/helpdesk/include/tickets.html
@@ -39,24 +39,31 @@
                             <!-- /.table-responsive -->
                             {% if ticket_list.has_other_pages %}
                                 <ul class="pagination">
+                                    <!-- if we aren't on page one, go back to start and go back one controls -->
                                     {% if ticket_list.has_previous %}
+                                        <li><a href=?{{ page_var }}=1">&laquo;&laquo;</a></li>
                                         <li><a href="?{{ page_var }}={{ ticket_list.previous_page_number }}">&laquo;</a></li>
                                     {% else %}
+                                        <li class="disabled"><span>&laquo;&laquo;</span></li>
                                         <li class="disabled"><span>&laquo;</span></li>
                                     {% endif %}
+                                    <!-- Page - 5 to page + 5 controls -->
                                     {% with ''|center:11 as range %}
                                     {% for _ in range %}
-                                        {% with (ticket_list.number + (forloop.counter-5)) as i %}
+                                        {% with ticket_list.number+forloop.counter-5 as i %}
                                         {% if ticket_list.number == i %}
                                             <li class="active"><span>{{ i }} <span class="sr-only">(current)</span></span></li>
-                                        {% else %}
+                                        {% else if ticket_list.pages%}
                                             <li><a href="?{{ page_var }}={{ i }}">{{ i }}</a></li>
                                         {% endif %}
                                     {% endfor %}
+                                    <!-- if we aren't on the last page, go forward one and go to end controls -->
                                     {% if ticket_list.has_next %}
                                         <li><a href="?{{ page_var }}={{ ticket_list.next_page_number }}">&raquo;</a></li>
+                                        <li><a href=?{{ page_var }}={{ ticket_list.paginator.num_pages }}">&raquo;&raquo;</a></li>
                                     {% else %}
                                         <li class="disabled"><span>&raquo;</span></li>
+                                        <li class="disabled"><span>&raquo;&raquo;</span></li>
                                     {% endif %}
                                 </ul>
                             {% endif %}

--- a/helpdesk/templates/helpdesk/include/tickets.html
+++ b/helpdesk/templates/helpdesk/include/tickets.html
@@ -53,7 +53,7 @@
                                         {% with ticket_list.number|add:forloop.counter|add:"-5" as i %}
                                         {% if ticket_list.number == i %}
                                             <li class="active"><span>{{ i }} <span class="sr-only">(current)</span></span></li>
-                                        {% else if ticket_list.pages%}
+                                        {% else if i in ticket_list.paginator.page_range %}
                                             <li><a href="?{{ page_var }}={{ i }}">{{ i }}</a></li>
                                         {% endif %}
                                     {% endfor %}

--- a/helpdesk/templates/helpdesk/include/tickets.html
+++ b/helpdesk/templates/helpdesk/include/tickets.html
@@ -52,7 +52,7 @@
                                     {% for i in ticket_list.paginator.page_range %}
                                         {% if ticket_list.number == i %}
                                             <li class="active"><span>{{ i }} <span class="sr-only">(current)</span></span></li>
-                                        {% else if i <= ticket_list.number|add:5 and i >= ticket_list.number|-5 %}
+                                        {% elif i <= ticket_list.number|add:5 and i >= ticket_list.number|-5 %}
                                             <li><a href="?{{ page_var }}={{ i }}">{{ i }}</a></li>
                                         {% endif %}
                                     {% endfor %}

--- a/helpdesk/templates/helpdesk/include/tickets.html
+++ b/helpdesk/templates/helpdesk/include/tickets.html
@@ -47,13 +47,12 @@
                                         <li class="disabled"><span>&laquo;&laquo;</span></li>
                                         <li class="disabled"><span>&laquo;</span></li>
                                     {% endif %}
-                                    <!-- Page - 5 to page + 5 controls -->
-                                    {% with ''|center:11 as range %}
-                                    {% for _ in range %}
-                                        {% with ticket_list.number|add:forloop.counter|add:"-5" as i %}
+                                    <!-- other pages, set thresh to the number to show before and after active -->
+                                    {% with 5 as thresh %}
+                                    {% for i in ticket_list.paginator.page_range %}
                                         {% if ticket_list.number == i %}
                                             <li class="active"><span>{{ i }} <span class="sr-only">(current)</span></span></li>
-                                        {% else if i in ticket_list.paginator.page_range %}
+                                        {% else if i <= ticket_list.number|add:5 and i >= ticket_list.number|-5 %}
                                             <li><a href="?{{ page_var }}={{ i }}">{{ i }}</a></li>
                                         {% endif %}
                                     {% endfor %}

--- a/helpdesk/templates/helpdesk/include/tickets.html
+++ b/helpdesk/templates/helpdesk/include/tickets.html
@@ -50,7 +50,7 @@
                                     <!-- Page - 5 to page + 5 controls -->
                                     {% with ''|center:11 as range %}
                                     {% for _ in range %}
-                                        {% with ticket_list.number|add:forloop.counter|sub:"5" as i %}
+                                        {% with ticket_list.number|add:forloop.counter|add:"-5" as i %}
                                         {% if ticket_list.number == i %}
                                             <li class="active"><span>{{ i }} <span class="sr-only">(current)</span></span></li>
                                         {% else if ticket_list.pages%}

--- a/helpdesk/templates/helpdesk/include/tickets.html
+++ b/helpdesk/templates/helpdesk/include/tickets.html
@@ -56,6 +56,7 @@
                                             <li><a href="?{{ page_var }}={{ i }}">{{ i }}</a></li>
                                         {% endif %}
                                     {% endfor %}
+                                    {% endwith %}
                                     <!-- if we aren't on the last page, go forward one and go to end controls -->
                                     {% if ticket_list.has_next %}
                                         <li><a href="?{{ page_var }}={{ ticket_list.next_page_number }}">&raquo;</a></li>

--- a/helpdesk/templates/helpdesk/include/tickets.html
+++ b/helpdesk/templates/helpdesk/include/tickets.html
@@ -50,7 +50,7 @@
                                     <!-- Page - 5 to page + 5 controls -->
                                     {% with ''|center:11 as range %}
                                     {% for _ in range %}
-                                        {% with ticket_list.number+forloop.counter-5 as i %}
+                                        {% with ticket_list.number|add:forloop.counter|sub:"5" as i %}
                                         {% if ticket_list.number == i %}
                                             <li class="active"><span>{{ i }} <span class="sr-only">(current)</span></span></li>
                                         {% else if ticket_list.pages%}

--- a/helpdesk/templates/helpdesk/include/tickets.html
+++ b/helpdesk/templates/helpdesk/include/tickets.html
@@ -41,7 +41,7 @@
                                 <ul class="pagination">
                                     <!-- if we aren't on page one, go back to start and go back one controls -->
                                     {% if ticket_list.has_previous %}
-                                        <li><a href=?{{ page_var }}=1">&laquo;&laquo;</a></li>
+                                        <li><a href="?{{ page_var }}=1">&laquo;&laquo;</a></li>
                                         <li><a href="?{{ page_var }}={{ ticket_list.previous_page_number }}">&laquo;</a></li>
                                     {% else %}
                                         <li class="disabled"><span>&laquo;&laquo;</span></li>
@@ -60,7 +60,7 @@
                                     <!-- if we aren't on the last page, go forward one and go to end controls -->
                                     {% if ticket_list.has_next %}
                                         <li><a href="?{{ page_var }}={{ ticket_list.next_page_number }}">&raquo;</a></li>
-                                        <li><a href=?{{ page_var }}={{ ticket_list.paginator.num_pages }}">&raquo;&raquo;</a></li>
+                                        <li><a href="?{{ page_var }}={{ ticket_list.paginator.num_pages }}">&raquo;&raquo;</a></li>
                                     {% else %}
                                         <li class="disabled"><span>&raquo;</span></li>
                                         <li class="disabled"><span>&raquo;&raquo;</span></li>

--- a/helpdesk/templates/helpdesk/include/tickets.html
+++ b/helpdesk/templates/helpdesk/include/tickets.html
@@ -46,7 +46,7 @@
                                     {% endif %}
                                     {% with ''|center:11 as range %}
                                     {% for _ in range %}
-                                        {% with i = ticket_list.number + (forloop.counter-5) %}
+                                        {% with (ticket_list.number + (forloop.counter-5)) as i %}
                                         {% if ticket_list.number == i %}
                                             <li class="active"><span>{{ i }} <span class="sr-only">(current)</span></span></li>
                                         {% else %}

--- a/helpdesk/templates/helpdesk/include/tickets.html
+++ b/helpdesk/templates/helpdesk/include/tickets.html
@@ -44,7 +44,9 @@
                                     {% else %}
                                         <li class="disabled"><span>&laquo;</span></li>
                                     {% endif %}
-                                    {% for i in ticket_list.paginator.page_range %}
+                                    {% with ''|center:11 as range %}
+                                    {% for _ in range %}
+                                        {% with i = ticket_list.number + (forloop.counter-5) %}
                                         {% if ticket_list.number == i %}
                                             <li class="active"><span>{{ i }} <span class="sr-only">(current)</span></span></li>
                                         {% else %}

--- a/helpdesk/templates/helpdesk/include/tickets.html
+++ b/helpdesk/templates/helpdesk/include/tickets.html
@@ -52,7 +52,7 @@
                                     {% for i in ticket_list.paginator.page_range %}
                                         {% if ticket_list.number == i %}
                                             <li class="active"><span>{{ i }} <span class="sr-only">(current)</span></span></li>
-                                        {% elif i <= ticket_list.number|add:5 and i >= ticket_list.number|-5 %}
+                                        {% elif i <= ticket_list.number|add:5 and i >= ticket_list.number|add:-5 %}
                                             <li><a href="?{{ page_var }}={{ i }}">{{ i }}</a></li>
                                         {% endif %}
                                     {% endfor %}

--- a/helpdesk/views/staff.py
+++ b/helpdesk/views/staff.py
@@ -94,7 +94,7 @@ def dashboard(request):
     """
 
     # user settings num tickets per page
-    tickets_per_page = request.user.usersettings_helpdesk.tickets_per_page
+    tickets_per_page = request.user.usersettings_helpdesk.settings.get('tickets_per_page') or 25
 
     # page vars for the three ticket tables
     user_tickets_page = request.GET.get('ut_page', 1)


### PR DESCRIPTION
simple change to the dashboard view and html files to allow pagination on the ticket tables generated by tickets.html.

staff.py

- read user ticket pp setting (used in the ticketing view), lets just recycle this instead of making a separate setting (or settings) per table. (line 96-97)

- expect new http get args for each table for user submitted tickets (atrbcu_page), user assigned tickets (ut_page), and user resolved tickets (utcr_page). If not passed, default to 1.  (line 99-102)

- use django core paginator functionality to split the ticket queryset(s) into pages, and pass only the requested page to dashboard.html (line 154-187)


helpdesk/templates/helpdesk/dashboard.html

- pass the correct http get arg to the include for three tables (lines 19-20, 25-26, 32-33)

helpdesk/templates/helpdesk/include/tickets.html

- add pagination controls for each table if it has more than the current page


Results:

No pagination required looks like this
![image](https://user-images.githubusercontent.com/4584035/83464502-ede25600-a425-11ea-8aa7-5f9680ad20c6.png)

W/ pagination required will look like this
![image](https://user-images.githubusercontent.com/4584035/83464529-f8045480-a425-11ea-9511-10f631fca1d6.png)
