### PR TITLE
fix<process_email>: free the log file handler after it's not used anymore

### DIFF
--- a/helpdesk/email.py
+++ b/helpdesk/email.py
@@ -74,18 +74,29 @@ def process_email(quiet=False):
         if quiet:
             logger.propagate = False  # do not propagate to root logger that would log to console
         logdir = q.logging_dir or '/var/log/helpdesk/'
-        handler = logging.FileHandler(join(logdir, q.slug + '_get_email.log'))
-        logger.addHandler(handler)
 
-        if not q.email_box_last_check:
-            q.email_box_last_check = timezone.now() - timedelta(minutes=30)
+        try:
+            handler = logging.FileHandler(join(logdir, q.slug + '_get_email.log'))
+            logger.addHandler(handler)
 
-        queue_time_delta = timedelta(minutes=q.email_box_interval or 0)
+            if not q.email_box_last_check:
+                q.email_box_last_check = timezone.now() - timedelta(minutes=30)
 
-        if (q.email_box_last_check + queue_time_delta) < timezone.now():
-            process_queue(q, logger=logger)
-            q.email_box_last_check = timezone.now()
-            q.save()
+            queue_time_delta = timedelta(minutes=q.email_box_interval or 0)
+
+            if (q.email_box_last_check + queue_time_delta) < timezone.now():
+                process_queue(q, logger=logger)
+                q.email_box_last_check = timezone.now()
+                q.save()
+        finally:
+            try:
+                handler.close()
+            except Exception as e:
+                logging.exception(e)
+            try:
+                logger.removeHandler(handler)
+            except Exception as e:
+                logging.exception(e)
 
 
 def pop3_sync(q, logger, server):


### PR DESCRIPTION
it's questionable to have file handler at all given some people will be running it in either long-living Docker environment with root file system read-only or very short-living with logs colected by the container manager, but anyway