### PR TITLE
added cancel changes button to edit ticket page

### DIFF
--- a/helpdesk/templates/helpdesk/edit_ticket.html
+++ b/helpdesk/templates/helpdesk/edit_ticket.html
@@ -40,6 +40,7 @@
     {% endcomment %}
     <div class='buttons form-group'>
         <input type='submit' class="btn btn-primary btn-sm" value='{% trans "Save Changes" %}' />
+        <a href='{{ ticket.get_absolute_url }}'><button class="btn btn-danger">{% trans "Cancel Changes" %}</button></a>
     </div>
 </fieldset>
 


### PR DESCRIPTION
Adds a new button to edit edit ticket page called "Cancel Changes", which, when clicked sends the user back to the ticket. Previously you would press the browser's back navigation button but this adds a little extra navigability using a button within the page.