### PR TITLE
customizable navigation header template for override and documentation update

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -74,3 +74,13 @@ The result is that if both crontab and *E-Mail Check Interval* are set to run at
 To avoid this problem set the crontab and *E-Mail Check Interval* to marginally different values (or set *E-Mail Check Interval* to ``0``). *E-Mail Check Interval* will only take an integer value, in minutes, so if you want a five minute interval between mail checks, then you will either have to set *E-Mail Check Interval* to ``4`` and the crontab interval to ``300 seconds``, or the *E-Mail Check Interval* to ``5`` and the crontab interval to ``305 seconds``.
 
 The crontab interval overrides the *E-Mail Check Interval*, and resets the *E-Mail Check Interval* each time it fires, as long as the crontab interval is greater than *E-Mail Check Interval*.
+
+Custom Navigation Header
+------------------------
+You may add own site specific navigation header to be included inside the <body> tag and before django-helpdesk navbar.
+
+1. Create an override template in your project's templates directory::
+
+       helpdesk/custom_navigation_header.html
+
+2. Update the contents to display your custom navigation.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -77,7 +77,7 @@ The crontab interval overrides the *E-Mail Check Interval*, and resets the *E-Ma
 
 Custom Navigation Header
 ------------------------
-You may add own site specific navigation header to be included inside the <body> tag and before django-helpdesk navbar.
+You may add your own site specific navigation header to be included inside the <body> tag and before django-helpdesk navbar.
 
 1. Create an override template in your project's templates directory::
 

--- a/helpdesk/templates/helpdesk/custom_navigation_header.html
+++ b/helpdesk/templates/helpdesk/custom_navigation_header.html
@@ -1,0 +1,1 @@
+{# Override this template in your own templates directory to customize #}

--- a/helpdesk/templates/helpdesk/navigation-header.html
+++ b/helpdesk/templates/helpdesk/navigation-header.html
@@ -1,5 +1,7 @@
 {% load i18n helpdesk_staff %}
 
+    {% include 'helpdesk/custom_navigation_header.html' %}
+
     <nav class="navbar navbar-expand navbar-dark bg-dark static-top">
 
       <a class="navbar-brand" href="{% url 'helpdesk:home' %}">{% trans 'Helpdesk' %}</a>


### PR DESCRIPTION
#878 contribution and applies to #864 (although not exactly as requested applies in principle to intent). This provides a blank html template to override and create a custom header above navigation.