### PR TITLE
Remove hard dependency on pinax teams

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -65,6 +65,8 @@ errors with trying to create User settings.
         'reversion',  # required by pinax-teams
     )
 
+   Note: you do not need to use pinax-teams. To dissable teams see the :doc:`teams` section.
+
    Your ``settings.py`` file should also define a ``SITE_ID`` that allows multiple projects to share
    a single database, and is required by ``django.contrib.sites`` in Django 1.9+.
    If you aren't running multiple sites, you can simply add a default ``SITE_ID`` to ``settings.py``::

--- a/docs/teams.rst
+++ b/docs/teams.rst
@@ -12,3 +12,5 @@ You can visit the 'Pinax Teams' page in your django admin in order to create a t
 You can assign a knowledge-base item to a team on the Helpdesk admin page.
 
 Once you have set up teams. Unassigned tickets which are associated with a knowledge-base item will only be shown on the dashboard to those users who are members of the team which is associated with that knowledge-base item.
+
+Note: It is possible that pinax-teams will interfere with other packages that you already use in your project. If you do not wish to use team functionality, you can dissable teams by setting the following settings: ``HELPDESK_TEAMS_MODEL`` to any random model, ``HELPDESK_TEAMS_MIGRATION_DEPENDENCIES`` to ``[]``, and ``HELPDESK_KBITEM_TEAM_GETTER`` to ``lambda _: None``. You can also use a different library in place of pinax teams by setting those settings appropriately. ``HELPDESK_KBITEM_TEAM_GETTER`` should take a ``kbitem`` and return a team object with a ``name`` property and a method ``is_member(self, user)`` which returns true if user is a member of the team.

--- a/helpdesk/migrations/0028_kbitem_team.py
+++ b/helpdesk/migrations/0028_kbitem_team.py
@@ -3,18 +3,19 @@
 from django.db import migrations, models
 import django.db.models.deletion
 
+from helpdesk import settings as helpdesk_settings
+
 
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('pinax_teams', '0004_auto_20170511_0856'),
         ('helpdesk', '0027_auto_20200107_1221'),
-    ]
+    ] + helpdesk_settings.HELPDESK_TEAMS_MIGRATION_DEPENDENCIES
 
     operations = [
         migrations.AddField(
             model_name='kbitem',
             name='team',
-            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, to='pinax_teams.Team', verbose_name='Team'),
+            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, to=helpdesk_settings.HELPDESK_TEAMS_MODEL, verbose_name='Team'),
         ),
     ]

--- a/helpdesk/models.py
+++ b/helpdesk/models.py
@@ -25,8 +25,6 @@ from django.utils.safestring import mark_safe
 from markdown import markdown
 from markdown.extensions import Extension
 
-import pinax.teams.models
-
 
 import uuid
 
@@ -1359,7 +1357,7 @@ class KBItem(models.Model):
     )
 
     team = models.ForeignKey(
-        pinax.teams.models.Team,
+        helpdesk_settings.HELPDESK_TEAMS_MODEL,
         on_delete=models.CASCADE,
         verbose_name=_('Team'),
         blank=True,
@@ -1381,6 +1379,9 @@ class KBItem(models.Model):
         if not self.last_updated:
             self.last_updated = timezone.now()
         return super(KBItem, self).save(*args, **kwargs)
+
+    def get_team(self):
+        return helpdesk_settings.HELPDESK_KBITEM_TEAM_GETTER(self)
 
     def _score(self):
         """ Return a score out of 10 or Unrated if no votes """

--- a/helpdesk/settings.py
+++ b/helpdesk/settings.py
@@ -155,3 +155,7 @@ HELPDESK_ENABLE_PER_QUEUE_STAFF_PERMISSION = getattr(
 
 # use https in the email links
 HELPDESK_USE_HTTPS_IN_EMAIL_LINK = getattr(settings, 'HELPDESK_USE_HTTPS_IN_EMAIL_LINK', False)
+
+HELPDESK_TEAMS_MODEL = getattr(settings, 'HELPDESK_TEAMS_MODEL', 'pinax_teams.Team')
+HELPDESK_TEAMS_MIGRATION_DEPENDENCIES = getattr(settings, 'HELPDESK_TEAMS_MIGRATION_DEPENDENCIES', [('pinax_teams', '0004_auto_20170511_0856')])
+HELPDESK_KBITEM_TEAM_GETTER = getattr(settings, 'HELPDESK_KBITEM_TEAM_GETTER', lambda kbitem: kbitem.team)

--- a/helpdesk/templates/helpdesk/include/unassigned.html
+++ b/helpdesk/templates/helpdesk/include/unassigned.html
@@ -43,7 +43,7 @@
 <div class="card mb-3">
     <div class="card-header">
         <i class="fas fa-table"></i>
-        {% trans "KBItem:" %} {{kbitem.title}} {% trans "Team:" %} {{kbitem.team.name}} {% trans "(pick up a ticket if you start to work on it)" %}
+        {% trans "KBItem:" %} {{kbitem.title}} {% trans "Team:" %} {{kbitem.get_team.name}} {% trans "(pick up a ticket if you start to work on it)" %}
     </div>
     <div class="card-body">
         <div class="table-responsive">

--- a/helpdesk/user.py
+++ b/helpdesk/user.py
@@ -46,7 +46,7 @@ class HelpdeskUser:
     def get_assigned_kb_items(self):
         kbitems = []
         for item in KBItem.objects.all():
-            if item.team and item.team.is_member(self.user):
+            if item.get_team() and item.get_team().is_member(self.user):
                 kbitems.append(item)
         return kbitems
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,3 @@ pytz
 six
 djangorestframework
 django-model-utils
-pinax-teams>=2.0


### PR DESCRIPTION
Sadly dealing with naming conflicts in django is quite a challenge in my experience. I think that the only way to solve https://github.com/django-helpdesk/django-helpdesk/issues/912 is to make it so that pinax-teams can be dissabled or replaced.