### PR TITLE
Add support for standard STARTTLS on port 143 (RFC 2595).

### DIFF
--- a/helpdesk/email.py
+++ b/helpdesk/email.py
@@ -101,6 +101,10 @@ def process_email(quiet=False):
 
 def pop3_sync(q, logger, server):
     server.getwelcome()
+    try:
+        server.stls()
+    except Exception:
+        logger.warning("POP3 StartTLS failed or unsupported. Connection will be unencrypted.")
     server.user(q.email_box_user or settings.QUEUE_EMAIL_BOX_USER)
     server.pass_(q.email_box_pass or settings.QUEUE_EMAIL_BOX_PASSWORD)
 
@@ -138,6 +142,10 @@ def pop3_sync(q, logger, server):
 
 def imap_sync(q, logger, server):
     try:
+        try:
+            server.starttl()
+        except Exception:
+            logger.warning("IMAP4 StartTLS unsupported or failed. Connection will be unencrypted.")
         server.login(q.email_box_user or
                      settings.QUEUE_EMAIL_BOX_USER,
                      q.email_box_pass or


### PR DESCRIPTION
Signed-off-by: Evili del Rio <evili.del.rio@gmail.com>

Adds support for connecting to IMAP and POP servers using standard port and STARTTLS (RFC-2595).
If StartTLS fails for some reason the connection will continue as plain text.