### PR TITLE
Fix some login errors

### DIFF
--- a/demo/demodesk/config/settings.py
+++ b/demo/demodesk/config/settings.py
@@ -108,8 +108,8 @@ HELPDESK_SHOW_CHANGE_PASSWORD = True
 # Instead of showing the public web portal first,
 # we can instead redirect users straight to the login page.
 HELPDESK_REDIRECT_TO_LOGIN_BY_DEFAULT = False
-LOGIN_URL = '/login/'
-LOGIN_REDIRECT_URL = '/login/'
+LOGIN_URL = 'helpdesk:login'
+LOGIN_REDIRECT_URL = 'helpdesk:home'
 
 # Database
 # - by default, we use SQLite3 for the demo, but you can also

--- a/helpdesk/urls.py
+++ b/helpdesk/urls.py
@@ -215,10 +215,6 @@ urlpatterns += [
     url(r'^login/$',
         login.login,
         name='login'),
-    
-    url(r'^accounts/login/$',
-        login.login,
-        name='login'),
 
     url(r'^logout/$',
         auth_views.LogoutView.as_view(


### PR DESCRIPTION
When making my PR #919 , I encountered issues to login on the demo app. So I try some fixes in the demo settings and also in `urls.py` where I removed a duplicate entry with name='login', which I think was causing the 302 error (too many redirects).

But since, I'm not too sure about this one, I leave it as a draft so that other can review it.