### PR TITLE
Fix #926

### DIFF
--- a/helpdesk/forms.py
+++ b/helpdesk/forms.py
@@ -98,6 +98,9 @@ class EditTicketForm(CustomFieldMixin, forms.ModelForm):
             try:
                 current_value = TicketCustomFieldValue.objects.get(ticket=self.instance, field=field)
                 initial_value = current_value.value
+                # If it is boolean field, transform the value to a real boolean instead of a string
+                if current_value.field.data_type == 'boolean':
+                    initial_value = initial_value == 'True'
             except TicketCustomFieldValue.DoesNotExist:
                 initial_value = None
             instanceargs = {


### PR DESCRIPTION
The initial value for a non required custom boolean field was not set properly in the edit ticket form.
It was using the value stored in the database as a string and since in Python : `'False' == True`, the checkbox was always checked.

I just added a condition where it translates to a real boolean before giving the initial value.