### PR TITLE
Disabled merged_to field in edit ticket + Fix datepicker

### DIFF
--- a/helpdesk/forms.py
+++ b/helpdesk/forms.py
@@ -83,6 +83,12 @@ class CustomFieldMixin(object):
 
 
 class EditTicketForm(CustomFieldMixin, forms.ModelForm):
+    merged_to = forms.ModelChoiceField(
+        label=_('Merged to'),
+        help_text=_('This ticket is merged into the selected ticket.'),
+        queryset=Ticket.objects.all(),
+        disabled=True
+    )
 
     class Meta:
         model = Ticket

--- a/helpdesk/templates/helpdesk/edit_ticket.html
+++ b/helpdesk/templates/helpdesk/edit_ticket.html
@@ -1,58 +1,52 @@
-{% extends "helpdesk/base.html" %}{% load i18n bootstrap4form %}
+{% extends "helpdesk/base.html" %}
+
+{% load i18n bootstrap4form %}
 
 {% block helpdesk_title %}{% trans "Edit Ticket" %}{% endblock %}
 
 {% block helpdesk_breadcrumb %}
-<li class="breadcrumb-item">
-    <a href="{% url 'helpdesk:list' %}">{% trans "Tickets" %}</a>
-</li>
-<li class="breadcrumb-item">
-    <a href="{% url 'helpdesk:list' %}{{ ticket.id }}/">{{ ticket.queue.slug }}-{{ ticket.id }}</a>
-</li>
-<li class="breadcrumb-item active">{% trans "Edit Ticket" %}</li>
+    <li class="breadcrumb-item">
+        <a href="{% url 'helpdesk:list' %}">{% trans "Tickets" %}</a>
+    </li>
+    <li class="breadcrumb-item">
+        <a href="{% url 'helpdesk:list' %}{{ ticket.id }}/">{{ ticket.queue.slug }}-{{ ticket.id }}</a>
+    </li>
+    <li class="breadcrumb-item active">{% trans "Edit Ticket" %}</li>
 {% endblock %}
 
 {% block helpdesk_body %}
-<div class="col-xs-6">
-<div class="panel panel-default">
-
-<div class="panel-body"><h2>{% trans "Edit a Ticket" %}</h2>
-
-<p>{% trans "Unless otherwise stated, all fields are required." %} {% trans "Please provide as descriptive a title and description as possible." %}</p>
-
-<p><strong>{% trans "Note" %}:</strong> {% blocktrans %}Editing a ticket does <em>not</em> send an e-mail to the ticket owner or submitter. No new details should be entered, this form should only be used to fix incorrect details or clean up the submission.{% endblocktrans %}</p>
-
-<form method='post' action='./'>
-<fieldset>
-    {{ form|bootstrap4form }}
-    {% comment %}
-        {% for field in form %}
-            {% if field.is_hidden %}
-                {{ field }}
-            {% else %}
-                <dt><label for='id_{{ field.name }}'>{{ field.label }}</label>{% if not field.field.required %} <span class='form_optional'>{% trans "(Optional)" %}</span>{% endif %}</dt>
-                <dd>{{ field }}</dd>
-                {% if field.errors %}<dd class='error'>{{ field.errors }}</dd>{% endif %}
-                {% if field.help_text %}<dd class='form_help_text'>{{ field.help_text }}</dd>{% endif %}</label>
-            {% endif %}
-        {% endfor %}
-    </dl>
-    {% endcomment %}
-    <div class='buttons form-group'>
-        <input type='submit' class="btn btn-primary btn-sm" value='{% trans "Save Changes" %}' />
-        <a href='{{ ticket.get_absolute_url }}'><button class="btn btn-danger">{% trans "Cancel Changes" %}</button></a>
+    <div class="col-xs-6">
+        <div class="panel panel-default">
+            <div class="panel-body"><h2>{% trans "Edit a Ticket" %}</h2>
+                <p>
+                    {% trans "Unless otherwise stated, all fields are required." %}
+                    {% trans "Please provide as descriptive a title and description as possible." %}
+                </p>
+                <p>
+                    <strong>{% trans "Note" %}:</strong>
+                    {% blocktrans %}Editing a ticket does <em>not</em> send an e-mail to the ticket owner or submitter. No new details should be entered, this form should only be used to fix incorrect details or clean up the submission.{% endblocktrans %}
+                </p>
+                <form method='post'>
+                    {% csrf_token %}
+                    <fieldset>
+                        {{ form|bootstrap4form }}
+                        <div class='buttons form-group'>
+                            <input type='submit' class="btn btn-primary btn-sm" value='{% trans "Save Changes" %}'/>
+                            <a href='{{ ticket.get_absolute_url }}'>
+                                <button class="btn btn-danger">{% trans "Cancel Changes" %}</button>
+                            </a>
+                        </div>
+                    </fieldset>
+                </form>
+            </div>
+        </div>
     </div>
-</fieldset>
+{% endblock %}
 
-{% csrf_token %}</form>
-    </div>
-  </div>
-</div>
-
-<script>
-$( function() {
-	$( "#id_due_date" ).datepicker({dateFormat: 'yy-mm-dd'});
-} );
-</script>
-
+{% block helpdesk_js %}
+    <script>
+        $(() => {
+            $("#id_due_date").datepicker({dateFormat: 'yy-mm-dd'});
+        })
+    </script>
 {% endblock %}

--- a/helpdesk/views/staff.py
+++ b/helpdesk/views/staff.py
@@ -1213,13 +1213,10 @@ def edit_ticket(request, ticket_id):
     ticket = get_object_or_404(Ticket, id=ticket_id)
     ticket_perm_check(request, ticket)
 
-    if request.method == 'POST':
-        form = EditTicketForm(request.POST, instance=ticket)
-        if form.is_valid():
-            ticket = form.save()
-            return HttpResponseRedirect(ticket.get_absolute_url())
-    else:
-        form = EditTicketForm(instance=ticket)
+    form = EditTicketForm(request.POST or None, instance=ticket)
+    if form.is_valid():
+        ticket = form.save()
+        return redirect(ticket)
 
     return render(request, 'helpdesk/edit_ticket.html', {'form': form, 'ticket': ticket})
 


### PR DESCRIPTION
Here is my PR to fix #938 

I override `merged_to` field in `EditTicketForm` in order to add a help text and set it as disabled since it make no sense to change that field without using the bulk action from the ticket list.

I also refactored the view and reformat the template for the edit ticket form. I noticed I could fix the datepicker (there was an error with the order of jquery import).