### PR TITLE
feat(forms): Ability to provide custom public ticket form

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -81,19 +81,19 @@ These changes are visible throughout django-helpdesk
 - **HELPDESK_EMAIL_FALLBACK_LOCALE** Fallback locale for templated emails when queue locale not found
 
   **Default:** ``HELPDESK_EMAIL_FALLBACK_LOCALE = "en"``
-  
+
 - **HELPDESK_MAX_EMAIL_ATTACHMENT_SIZE** Maximum size, in bytes, of file attachments that will be sent via email
 
   **Default:** ``HELPDESK_MAX_EMAIL_ATTACHMENT_SIZE = 512000``
-  
+
 - **QUEUE_EMAIL_BOX_UPDATE_ONLY** Only process mail with a valid tracking ID; all other mail will be ignored instead of creating a new ticket.
 
   **Default:** ``QUEUE_EMAIL_BOX_UPDATE_ONLY = False``
-  
+
 - **HELPDESK_ANON_ACCESS_RAISES_404** If True, redirects user to a 404 page when attempting to reach ticket pages while not logged in, rather than redirecting to a login screen.
 
   **Default:** ``HELPDESK_ANON_ACCESS_RAISES_404 = False``
-  
+
 Options shown on public pages
 -----------------------------
 
@@ -106,6 +106,10 @@ These options only change display of items on public-facing pages, not staff pag
 - **HELPDESK_SUBMIT_A_TICKET_PUBLIC** Show 'submit a ticket' section & form on public page?
 
   **Default:** ``HELPDESK_SUBMIT_A_TICKET_PUBLIC = True``
+
+- **HELPDESK_PUBLIC_TICKET_FORM_CLASS** Define custom form class to show on public pages for anon users. You can use it for adding custom fields and validation, captcha and so on.
+
+  **Default:** ``HELPDESK_PUBLIC_TICKET_FORM_CLASS = "helpdesk.forms.PublicTicketForm"``
 
 
 Options for public ticket submission form

--- a/helpdesk/settings.py
+++ b/helpdesk/settings.py
@@ -79,6 +79,13 @@ HELPDESK_VIEW_A_TICKET_PUBLIC = getattr(settings, 'HELPDESK_VIEW_A_TICKET_PUBLIC
 # show 'submit a ticket' section on public page?
 HELPDESK_SUBMIT_A_TICKET_PUBLIC = getattr(settings, 'HELPDESK_SUBMIT_A_TICKET_PUBLIC', True)
 
+# change that to custom class to have extra fields or validation (like captcha)
+HELPDESK_PUBLIC_TICKET_FORM_CLASS = getattr(
+    settings,
+    "HELPDESK_PUBLIC_TICKET_FORM_CLASS",
+    "helpdesk.forms.PublicTicketForm"
+)
+
 
 ###################################
 # options for update_ticket views #

--- a/helpdesk/views/public.py
+++ b/helpdesk/views/public.py
@@ -7,6 +7,7 @@ views/public.py - All public facing views, eg non-staff (no authentication
                   required) views.
 """
 import logging
+from importlib import import_module
 
 from django.core.exceptions import (
     ObjectDoesNotExist, PermissionDenied, ImproperlyConfigured,
@@ -26,7 +27,6 @@ from helpdesk import settings as helpdesk_settings
 from helpdesk.decorators import protect_view, is_helpdesk_staff
 import helpdesk.views.staff as staff
 import helpdesk.views.abstract_views as abstract_views
-from helpdesk.forms import PublicTicketForm
 from helpdesk.lib import text_is_spam
 from helpdesk.models import CustomField, Ticket, Queue, UserSettings, KBCategory, KBItem
 from helpdesk.user import huser_from_request
@@ -42,7 +42,17 @@ def create_ticket(request, *args, **kwargs):
 
 
 class BaseCreateTicketView(abstract_views.AbstractCreateTicketMixin, FormView):
-    form_class = PublicTicketForm
+
+    def get_form_class(self):
+        try:
+            the_module, the_form_class = helpdesk_settings.HELPDESK_PUBLIC_TICKET_FORM_CLASS.rsplit(".", 1)
+            the_module = import_module(the_module)
+            the_form_class = getattr(the_module, the_form_class)
+        except Exception as e:
+            raise ImproperlyConfigured(
+                f"Invalid custom form class {helpdesk_settings.HELPDESK_PUBLIC_TICKET_FORM_CLASS}"
+            ) from e
+        return the_form_class
 
     def dispatch(self, *args, **kwargs):
         request = self.request


### PR DESCRIPTION
Works for me with custom form; and the tests are broken the same way they were before my changes so it's fine.

probably won't be useful for many people but django-allauth uses the same behaviour which means it's useful for at least some

not sure if you have feature freeze already in place - in this case this PR may wait for the next release
