### PR TITLE
Prevent filename collisions when processing attachments

### DIFF
--- a/helpdesk/email.py
+++ b/helpdesk/email.py
@@ -551,6 +551,8 @@ def object_from_message(message, queue, logger):
             if not name:
                 ext = mimetypes.guess_extension(part.get_content_type())
                 name = "part-%i%s" % (counter, ext)
+            else:
+                name = ("part-%i_" % counter) + name
 
             # FIXME: this code gets the paylods, then does something with it and then completely ignores it
             # writing the part.get_payload(decode=True) instead; and then the payload variable is


### PR DESCRIPTION
I hit an issue where attachments get lost when they have duplicate filenames in the same email. Because they get uploaded to the file backend using whatever filename was provided, duplicate names result in only one attachment getting saved. My solution to this is to prepend all file attachments with the message part index, similar to what gets used when there is no filename.