### PR TITLE
fix(emails): Avoid 'value too long for type character varying(200) ' …

### DIFF
--- a/helpdesk/models.py
+++ b/helpdesk/models.py
@@ -788,6 +788,9 @@ class Ticket(models.Model):
 
         self.modified = timezone.now()
 
+        if len(self.title) > 200:
+            self.title = self.title[:197] + "..."
+
         super(Ticket, self).save(*args, **kwargs)
 
     @staticmethod

--- a/helpdesk/tests/test_files/blank-body-with-attachment.eml
+++ b/helpdesk/tests/test_files/blank-body-with-attachment.eml
@@ -1,6 +1,6 @@
 To: helpdesk@auto-mat.cz
 From: Timothy Hobbs <timothy.hobbs@auto-mat.cz>
-Subject: Attachment without body
+Subject: Attachment without body - and a looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong subject
 Openpgp: preference=signencrypt
 Message-ID: <b05893cd-77b5-3450-4b84-9a1ad5119def@auto-mat.cz>
 Date: Fri, 15 Feb 2019 13:58:05 +0100

--- a/helpdesk/tests/test_get_email.py
+++ b/helpdesk/tests/test_get_email.py
@@ -53,7 +53,13 @@ class GetEmailCommonTests(TestCase):
         with open(os.path.join(THIS_DIR, "test_files/blank-body-with-attachment.eml")) as fd:
             test_email = fd.read()
         ticket = helpdesk.email.object_from_message(test_email, self.queue_public, self.logger)
-        self.assertEqual(ticket.title, "Attachment without body")
+
+        # title got truncated because of max_lengh of the model.title field
+        assert ticket.title == (
+            "Attachment without body - and a loooooooooooooooooooooooooooooooooo"
+            "ooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
+            "ooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo..."
+        )
         self.assertEqual(ticket.description, "")
 
     def test_email_with_quoted_printable_body(self):


### PR DESCRIPTION
…error when incoming message has too long subject