### PR TITLE
Iframe defaults fix

### DIFF
--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -13,6 +13,6 @@ There is also a page under the url `/tickets/submit_iframe/` with the same behav
 
 Fields may be hidden by adding them to a comma separated `_hide_fieds_` query parameter.
 
-Here is an example url to get you started: `http://localhost:8000/desk/tickets/submit_iframe/?queue=1;custom_dpnk-user=http://lol.cz;submitter_email=foo@bar.cz;title=lol;_hide_fields_=title,queue,submitter_email`. This url sets the queue to 1, sets the custom field `dpnk-url` to `http://lol.cz` and submitter_email to `lol@baz.cz` and hides the title, queue, and submitter_email fields. Note that hidden fields should be set to a default.
+Here is an example url to get you started: `http://localhost:8000/desk/tickets/submit_iframe/?queue=1&custom_dpnk-user=http://lol.cz;submitter_email=foo@bar.cz&title=lol&_hide_fields_=title,queue,submitter_email`. This url sets the queue to 1, sets the custom field `dpnk-url` to `http://lol.cz` and submitter_email to `lol@baz.cz` and hides the title, queue, and submitter_email fields. Note that hidden fields should be set to a default.
 
 Note that these fields will continue to be user-editable despite being pre-filled.

--- a/helpdesk/forms.py
+++ b/helpdesk/forms.py
@@ -421,20 +421,22 @@ class PublicTicketForm(AbstractTicketForm):
         super(PublicTicketForm, self).__init__(*args, **kwargs)
         self._add_form_custom_fields(False)
 
-        field_hide_table = {
+        for field in self.fields.keys():
+            if field in hidden_fields:
+                self.fields[field].widget = forms.HiddenInput()
+            if field in readonly_fields:
+                self.fields[field].disabled = True
+
+        field_deletion_table = {
             'queue': 'HELPDESK_PUBLIC_TICKET_QUEUE',
             'priority': 'HELPDESK_PUBLIC_TICKET_PRIORITY',
             'due_date': 'HELPDESK_PUBLIC_TICKET_DUE_DATE',
         }
 
-        for field_name, field_setting_key in field_hide_table.items():
+        for field_name, field_setting_key in field_deletion_table.items():
             has_settings_default_value = getattr(settings, field_setting_key, None)
             if has_settings_default_value is not None:
-                hidden_fields += (field_name,)
-
-        for field in hidden_fields:
-            if field in self.fields:
-                del self.fields[field]
+                del self.fields[field_name]
 
         public_queues = Queue.objects.filter(allow_public_submission=True)
 

--- a/helpdesk/templates/helpdesk/kb_category_base.html
+++ b/helpdesk/templates/helpdesk/kb_category_base.html
@@ -35,7 +35,7 @@
                 </a>
 
                 {% endif %}
-                <a href='{% if iframe %}{% url 'helpdesk:submit_iframe' %}{% else %}{% url 'helpdesk:submit' %}{%endif%}?{% if category.queue %}queue={{category.queue.pk}};_readonly_fields_=queue;{%endif%}kbitem={{item.id}};{{query_param_string}}' class="col-sm">
+                <a href='{% if iframe %}{% url 'helpdesk:submit_iframe' %}{% else %}{% url 'helpdesk:submit' %}{%endif%}?{% if category.queue %}queue={{category.queue.pk}}&_readonly_fields_=queue&{%endif%}kbitem={{item.id}}&{{query_param_string}}' class="col-sm">
                     <div class="btn btn-success btn-circle btn-xl float-right"><i  class="fa fa-plus-circle fa-lg"></i> {% trans 'Create New Ticket' %}{% trans " Queue: " %}{{item}}</div>
                 </a>
             </div>

--- a/helpdesk/tests/test_kb.py
+++ b/helpdesk/tests/test_kb.py
@@ -74,7 +74,7 @@ class KBTests(TestCase):
         self.assertContains(response, '0 people found this answer useful of 1')
 
     def test_kb_category_iframe(self):
-        cat_url = reverse('helpdesk:kb_category', args=("test_cat",)) + "?kbitem=1;submitter_email=foo@bar.cz;title=lol;"
+        cat_url = reverse('helpdesk:kb_category', args=("test_cat",)) + "?kbitem=1&submitter_email=foo@bar.cz&title=lol&"
         response = self.client.get(cat_url)
         # Assert that query params are passed on to ticket submit form
-        self.assertContains(response, "'/helpdesk/tickets/submit/?queue=1;_readonly_fields_=queue;kbitem=1;submitter_email=foo%40bar.cz&amp;title=lol")
+        self.assertContains(response, "'/helpdesk/tickets/submit/?queue=1&_readonly_fields_=queue&kbitem=1&submitter_email=foo%40bar.cz&amp;title=lol")

--- a/helpdesk/tests/test_ticket_submission.py
+++ b/helpdesk/tests/test_ticket_submission.py
@@ -95,6 +95,26 @@ class TicketBasicsTestCase(TestCase):
         # Follow up is anonymous
         self.assertIsNone(ticket.followup_set.first().user)
 
+
+    def test_create_ticket_public_with_hidden_fields(self):
+        email_count = len(mail.outbox)
+
+        response = self.client.get(reverse('helpdesk:home'))
+        self.assertEqual(response.status_code, 200)
+
+        post_data = {
+            'title': 'Test ticket title',
+            'queue': self.queue_public.id,
+            'submitter_email': 'ticket1.submitter@example.com',
+            'body': 'Test ticket body',
+            'priority': 4,
+        }
+
+        response = self.client.post(reverse('helpdesk:home') + "?_hide_fields_=priority", post_data, follow=True)
+        ticket = Ticket.objects.last()
+        self.assertEqual(ticket.priority, 4)
+
+
     def test_create_ticket_authorized(self):
         email_count = len(mail.outbox)
         self.client.force_login(self.user)
@@ -1068,7 +1088,7 @@ class EmailInteractionsTestCase(TestCase):
             answer="A KB Item",
         )
         self.kbitem1.save()
-        cat_url = reverse('helpdesk:submit') + "?kbitem=1;submitter_email=foo@bar.cz;title=lol;"
+        cat_url = reverse('helpdesk:submit') + "?kbitem=1&submitter_email=foo@bar.cz&title=lol"
         response = self.client.get(cat_url)
         self.assertContains(response, '<option value="1" selected>KBItem 1</option>')
         self.assertContains(response, '<input type="email" name="submitter_email" value="foo@bar.cz" class="form-control form-control" required id="id_submitter_email">')


### PR DESCRIPTION
Really not sure what happened here but it seems that django stopped supporting `;` as a query arg delimiter and now only supports `&`.