### PR TITLE
fix: strip extraneous whitespace characters that are returned in the …

### DIFF
--- a/helpdesk/email.py
+++ b/helpdesk/email.py
@@ -362,6 +362,12 @@ def create_object_from_email_message(message, ticket_id, payload, files, logger)
     message_id = message.get('Message-Id')
     in_reply_to = message.get('In-Reply-To')
 
+    if message_id:
+        message_id = message_id.strip()
+
+    if in_reply_to:
+        in_reply_to = in_reply_to.strip()
+
     if in_reply_to is not None:
         try:
             queryset = FollowUp.objects.filter(message_id=in_reply_to).order_by('-date')


### PR DESCRIPTION
…Message-ID and In-Reply-To fields from some email providers

This issue was discovered while testing the latest master branch in our production helpdesk system. All tickets that were associated with an Outlook-based email were causing our email processing to fail with a message like this:

```
ipdb> send_templated_mail(template, context, recipient, sender=self.queue.from_address, **kwargs)                                                                                                                  
*** postmark.core.PMMailUnprocessableEntityException: "Unprocessable Entity: Invalid header name 'In-Reply-To' or value '\r\n <DM5PR02MB3291D43715DE179CF89CC101DFA29@DM5PR02MB3291.namprd02.prod.outlook.com>'."
```

This was not an issue in previous django-helpdesk releases, so it seemed appropriate to address it here. Removing the surrounding whitespace characters in the Message-ID and In-Reply-To fields appears to have fixed the issue for us.