### PR TITLE
Add function `htmlEntities` into template ticket_list.html

### DIFF
--- a/helpdesk/templates/helpdesk/ticket_list.html
+++ b/helpdesk/templates/helpdesk/ticket_list.html
@@ -330,7 +330,11 @@
         function get_url(row) {
             return "{% url 'helpdesk:view' 1234 %}".replace(/1234/, row.id.toString());
         }
-
+        
+        function htmlEntities(str) {
+            return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+        }
+        
         $(document).ready(function () {
             // Ticket DataTable Initialization
             $('#ticketTable').DataTable({
@@ -366,7 +370,7 @@
                             if (type === 'display') {
                                 data = '<div class="tickettitle"><a href="' + get_url(row) + '" >' +
                                     row.id + '. ' +
-                                    row.title + '</a></div>';
+                                    htmlEntities(row.title) + '</a></div>';
                             }
                             return data
                         }


### PR DESCRIPTION
`htmlentities()` is a function which converts special characters. This allows you to show to display the string without the browser reading it as HTML.

Fix bug `Cross-site Scripting (XSS) - Stored in django-helpdesk/django-helpdesk`
Disclosure: https://huntr.dev/bounties/745f483c-70ed-441f-ab2e-7ac1305439a4/
CVE: CVE-2021-3945