### PR TITLE
Update task registration in line with Celery changes

### DIFF
--- a/helpdesk/tasks.py
+++ b/helpdesk/tasks.py
@@ -1,8 +1,8 @@
-from celery.decorators import task
+from celery import shared_task
 
 from .email import process_email
 
 
-@task()
+@shared_task
 def helpdesk_process_email():
     process_email()


### PR DESCRIPTION
Following https://docs.celeryproject.org/en/stable/internals/deprecation.html the importing of the celery task decorator needs to be updated for use with the current version of the celery package.