### PR TITLE
Some tests are skipped due to duplicate names fix

### DIFF
--- a/helpdesk/tests/test_ticket_submission.py
+++ b/helpdesk/tests/test_ticket_submission.py
@@ -1004,7 +1004,7 @@ class EmailInteractionsTestCase(TestCase):
         expected_email_count += 1
         self.assertEqual(expected_email_count, len(mail.outbox))
 
-    def test_create_followup_from_email_with_valid_message_id_with_original_cc_list_included(self):
+    def test_create_followup_from_email_with_valid_message_id_with_original_cc_list_included_two(self):
         """
         Ensure that if a message is received with an valid In-Reply-To ID,
         the expected <TicketCC> instances are created even if the there were


### PR DESCRIPTION
Fixes #995.

These tests were overriding other tests in the same file with the same name. I renamed so the tests run. Please give the tests a better name than I used. Naming is hard and I'm just a bot :)

This might result in tests failing because the affected tests were previously not running.

