### PR TITLE
GitHub workflow tools flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,3 +2,10 @@
 max-line-length = 120
 exclude = .git,__pycache__,.tox,.eggs,*.egg,node_modules,.venv,migrations,docs,demo,tests,setup.py
 import-order-style = pep8
+
+[pycodestyle]
+max-line-length = 120
+exclude = "migrations"
+in-place = true
+recursive = true
+

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -20,6 +20,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt -r requirements-testing.txt -c constraints-Django32.txt
+      name: autopep8
+      run: |
+        pip install autopep8
+        autopep8 --exit-code --global-config .flake8 helpdesk
     # - name: Lint with flake8
     #   run: |
         # pip install flake8

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -20,7 +20,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt -r requirements-testing.txt -c constraints-Django32.txt
-    - name: autopep8
+    - name: Format style check with 'autopep8'
       run: |
         pip install autopep8
         autopep8 --exit-code --global-config .flake8 helpdesk

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -24,13 +24,13 @@ jobs:
       run: |
         pip install autopep8
         autopep8 --exit-code --global-config .flake8 helpdesk
-    # - name: Lint with flake8
-    #   run: |
-        # pip install flake8
+    - name: Lint with flake8
+      run: |
+        pip install flake8
         # stop the build if there are Python syntax errors or undefined names
-        # flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        flake8 helpdesk --count --show-source --statistics --exit-zero
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        # flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        # flake8 . --count --exit-zero --max-complexity=10 --statistics
     - name: Test with pytest
       run: |
         pip install pytest

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -20,7 +20,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt -r requirements-testing.txt -c constraints-Django32.txt
-      name: autopep8
+    - name: autopep8
       run: |
         pip install autopep8
         autopep8 --exit-code --global-config .flake8 helpdesk

--- a/helpdesk/admin.py
+++ b/helpdesk/admin.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
 from django.utils.translation import gettext_lazy as _
-from helpdesk.models import Queue, Ticket, FollowUp, PreSetReply, KBCategory
-from helpdesk.models import EscalationExclusion, EmailTemplate, KBItem
+from helpdesk.models import Queue, Ticket, FollowUp, PreSetReply
+from helpdesk.models import EscalationExclusion, EmailTemplate
 from helpdesk.models import TicketChange, KBIAttachment, FollowUpAttachment, IgnoreEmail
 from helpdesk.models import CustomField
 from helpdesk import settings as helpdesk_settings
@@ -82,9 +82,10 @@ if helpdesk_settings.HELPDESK_KB_ENABLED:
 
         list_display_links = ('title',)
 
-    @admin.register(KBCategory)
-    class KBCategoryAdmin(admin.ModelAdmin):
-        list_display = ('name', 'title', 'slug', 'public')
+    if helpdesk_settings.HELPDESK_KB_ENABLED:
+        @admin.register(KBCategory)
+        class KBCategoryAdmin(admin.ModelAdmin):
+            list_display = ('name', 'title', 'slug', 'public')
 
 
 @admin.register(CustomField)

--- a/helpdesk/forms.py
+++ b/helpdesk/forms.py
@@ -7,7 +7,7 @@ forms.py - Definitions of newforms-based forms for creating and maintaining
            tickets.
 """
 import logging
-from datetime import datetime, date, time
+from datetime import datetime
 
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django import forms
@@ -226,7 +226,10 @@ class AbstractTicketForm(CustomFieldMixin, forms.Form):
         widget=forms.FileInput(attrs={'class': 'form-control-file'}),
         required=False,
         label=_('Attach File'),
-        help_text=_('You can attach a file to this ticket. Only file types such as plain text (.txt), a document (.pdf, .docx, or .odt), or screenshot (.png or .jpg) may be uploaded.'),
+        help_text=_('You can attach a file to this ticket. '
+                    'Only file types such as plain text (.txt), '
+                    'a document (.pdf, .docx, or .odt), '
+                    'or screenshot (.png or .jpg) may be uploaded.'),
     )
 
     class Media:

--- a/helpdesk/models.py
+++ b/helpdesk/models.py
@@ -60,7 +60,7 @@ def get_markdown(text):
     if not text:
         return ""
 
-    pattern = fr'([\[\s\S\]]*?)\(([\s\S]*?):([\s\S]*?)\)'
+    pattern = r'([\[\s\S\]]*?)\(([\s\S]*?):([\s\S]*?)\)'
     # Regex check
     if re.match(pattern, text):
         # get get value of group regex

--- a/quicktest.py
+++ b/quicktest.py
@@ -36,14 +36,14 @@ class QuickDjangoTest(object):
         'django.contrib.sites',
         'django.contrib.staticfiles',
         'bootstrap4form',
-        # The following commented apps are optional,
-        # related to teams functionalities
-        #'account',
-        #'pinax.invitations',
-        #'pinax.teams',
+        #  The following commented apps are optional,
+        #  related to teams functionalities
+        # 'account',
+        # 'pinax.invitations',
+        # 'pinax.teams',
         'rest_framework',
         'helpdesk',
-        #'reversion',
+        # 'reversion',
     )
     MIDDLEWARE = [
         'django.middleware.security.SecurityMiddleware',


### PR DESCRIPTION
Requires https://github.com/django-helpdesk/django-helpdesk/pull/1032.

Adds flake8 check, max complexity is disabled for the moment, the following needs addressing:
```./helpdesk/models.py:400:5: C901 'Queue.save' is too complex (11)
./helpdesk/email.py:151:1: C901 'imap_sync' is too complex (13)
./helpdesk/email.py:210:1: C901 'process_queue' is too complex (12)
./helpdesk/email.py:371:1: C901 'create_object_from_email_message' is too complex (21)
./helpdesk/email.py:519:1: C901 'object_from_message' is too complex (29)
./helpdesk/templated_email.py:11:1: C901 'send_templated_mail' is too complex (14)
./helpdesk/forms.py:38:5: C901 'CustomFieldMixin.customfield_to_field' is too complex (12)
./helpdesk/management/commands/escalate_tickets.py:145:1: C901 'If 145' is too complex (11)
./helpdesk/management/commands/create_escalation_exclusions.py:119:1: C901 'If 119' is too complex (14)
./helpdesk/views/staff.py:98:1: C901 'dashboard' is too complex (12)
./helpdesk/views/staff.py:476:1: C901 'update_ticket' is too complex (43)
./helpdesk/views/staff.py:773:1: C901 'mass_update' is too complex (18)
./helpdesk/views/staff.py:902:1: C901 'merge_tickets' is too complex (27)
./helpdesk/views/staff.py:1051:1: C901 'ticket_list' is too complex (26)
./helpdesk/views/staff.py:1412:1: C901 'run_report' is too complex (36)
./helpdesk/views/public.py:185:1: C901 'view_ticket' is too complex (11)
16    C901 'imap_sync' is too complex (13)
```

The above is the result with max complexity set to 10, this tends to be quite limiting and generally I would up this to 15-20 (mainly to play nicely when overloading class based views).

If you could let me know what you'd like this setting to, then I can make a start on cleaning up the offending code :-)