### PR TITLE
Add django-cleanup app to support deleting file system files

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -63,6 +63,7 @@ errors with trying to create User settings.
         'pinax.teams',  # Team support
         'reversion',  # Required by pinax-teams
         'rest_framework',  # required for the API
+        'django_cleanup.apps.CleanupConfig',  # Remove this if you do NOT want to delete fiels on the file system when the associated record is deleted in the database
         'helpdesk',  # This is us!
     )
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -63,7 +63,7 @@ errors with trying to create User settings.
         'pinax.teams',  # Team support
         'reversion',  # Required by pinax-teams
         'rest_framework',  # required for the API
-        'django_cleanup.apps.CleanupConfig',  # Remove this if you do NOT want to delete fiels on the file system when the associated record is deleted in the database
+        'django_cleanup.apps.CleanupConfig',  # Remove this if you do NOT want to delete files on the file system when the associated record is deleted in the database
         'helpdesk',  # This is us!
     )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ six
 pinax_teams
 djangorestframework
 django-model-utils
+django-cleanup


### PR DESCRIPTION
This relates to this issue:
https://github.com/django-helpdesk/django-helpdesk/issues/976

If deleting files is not desired, the end user can remove the app from INSTALLED_APPS