### PR TITLE
Fix fail email check when an attachment has a wrong extension

### DIFF
--- a/helpdesk/email.py
+++ b/helpdesk/email.py
@@ -478,12 +478,16 @@ def create_object_from_email_message(message, ticket_id, payload, files, logger)
 
     logger.info("[%s-%s] %s" % (ticket.queue.slug, ticket.id, ticket.title,))
 
-    attached = process_attachments(f, files)
-    for att_file in attached:
-        logger.info(
-            "Attachment '%s' (with size %s) successfully added to ticket from email.",
-            att_file[0], att_file[1].size
-        )
+    try:
+        attached = process_attachments(f, files)
+    except ValidationError as e:
+        logger.error(str(e))
+    else:
+        for att_file in attached:
+            logger.info(
+                "Attachment '%s' (with size %s) successfully added to ticket from email.",
+                att_file[0], att_file[1].size
+            )
 
     context = safe_template_context(ticket)
 

--- a/helpdesk/forms.py
+++ b/helpdesk/forms.py
@@ -7,6 +7,7 @@ forms.py - Definitions of newforms-based forms for creating and maintaining
            tickets.
 """
 
+
 from datetime import datetime
 from django import forms
 from django.conf import settings
@@ -33,6 +34,7 @@ from helpdesk.settings import (
     CUSTOMFIELD_TIME_FORMAT,
     CUSTOMFIELD_TO_FIELD_DICT
 )
+from helpdesk.validators import validate_file_extension
 import logging
 
 
@@ -243,6 +245,7 @@ class AbstractTicketForm(CustomFieldMixin, forms.Form):
                     'Only file types such as plain text (.txt), '
                     'a document (.pdf, .docx, or .odt), '
                     'or screenshot (.png or .jpg) may be uploaded.'),
+        validators=[validate_file_extension]
     )
 
     class Media:

--- a/helpdesk/tests/utils.py
+++ b/helpdesk/tests/utils.py
@@ -161,7 +161,7 @@ def generate_image_mime_part(locale: str="en_US",imagename: str = None) -> Messa
     :param locale: change this to generate locale specific file name and attachment content
     :param filename: pass a file name if you want to specify a specific name otherwise a random name will be generated
     """
-    part = MIMEImage(generate_random_image(image_format="JPEG"))
+    part = MIMEImage(generate_random_image(image_format="JPEG", array_dims=(200, 200)))
     part.set_payload(get_fake("text", locale=locale, min_length=1024))
     encoders.encode_base64(part)
     if not imagename:
@@ -206,7 +206,7 @@ def add_simple_email_headers(message: Message, locale: str="en_US",
 def generate_mime_part(locale: str="en_US",
         part_type: str="plain",
         use_short_email: bool=False
-        ) -> typing.Tuple[Message, typing.Tuple[str, str], typing.Tuple[str, str]]:
+        ) -> typing.Optional[Message]:
     """
     Generates amime part of the sepecified type
     
@@ -222,10 +222,8 @@ def generate_mime_part(locale: str="en_US",
         msg = MIMEText(body)
     elif "file" == part_type:
         msg = generate_file_mime_part(locale=locale)
-        msg = MIMEText(body)
     elif "image" == part_type:
         msg = generate_image_mime_part(locale=locale)
-        msg = MIMEText(body)
     else:
         raise Exception("Mime part not implemented: " + part_type)
     return msg
@@ -243,7 +241,7 @@ def generate_multipart_email(locale: str="en_US",
     """    
     msg = MIMEMultipart()
     for part_type in type_list:
-        msg.append(generate_mime_part(locale=locale, part_type=part_type, use_short_email=use_short_email))
+        msg.attach(generate_mime_part(locale=locale, part_type=part_type, use_short_email=use_short_email))
     from_meta, to_meta = add_simple_email_headers(msg, locale=locale, use_short_email=use_short_email)
     return msg, from_meta, to_meta
 

--- a/helpdesk/validators.py
+++ b/helpdesk/validators.py
@@ -4,6 +4,7 @@
 
 
 from django.conf import settings
+from django.utils.translation import gettext as _
 
 
 # TODO: can we use the builtin Django validator instead?
@@ -32,4 +33,5 @@ def validate_file_extension(value):
         # should always allow that?
         if not (ext.lower() == '' or ext.lower() == '.'):
             raise ValidationError(
-                'Unsupported file extension: %s.' % ext.lower())
+                _('Unsupported file extension: ') + ext.lower()
+            )


### PR DESCRIPTION
I used a try except in the `email.py` command in order to mute the ValidationError. I added one test to validate it.

I also add the validator on the files field of the `AbstractTicketForm`.