### PR TITLE
Remove link to heroku demo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,9 +17,6 @@ contributors reaching far beyond Jutda.
 Complete documentation is available in the docs/ directory,
 or online at http://django-helpdesk.readthedocs.org/.
 
-You can see a demo installation at https://django-helpdesk-demo.herokuapp.com/,
-or run a demo locally in just a couple steps!
-
 Demo Quickstart
 ---------------
 


### PR DESCRIPTION
Heroku notified me that the free tier is going away November 28th. There does not seem to be any allowance for open source projects at this time. I previously sent an email to them asking about it and only got a form letter that they'd be in touch if they decide to expand their tiers, so I'm going to guess it's not going to happen at this point.

So I am starting this PR just to alert folks the demo site will be going away on or before November 28th.

If there's interested in a new demo site, perhaps we can do it on pythonanywhere.com?

I have largely taken a step back from maintaining this project due to personal life so leave the decision up to the community and if there's a volunteer to maintain a new demo site. Otherwise, we can just accept this PR and remove the heroku link.