### PR TITLE
Bug fix for #1066 - detected due date change when no change was made

### DIFF
--- a/helpdesk/views/staff.py
+++ b/helpdesk/views/staff.py
@@ -23,10 +23,10 @@ from django.http import Http404, HttpResponse, HttpResponseRedirect, JsonRespons
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse, reverse_lazy
 from django.utils import timezone
-from django.utils.html import escape
-from django.utils.translation import gettext as _
 from django.utils.dateparse import parse_datetime
+from django.utils.html import escape
 from django.utils.timezone import make_aware
+from django.utils.translation import gettext as _
 from django.views.decorators.csrf import requires_csrf_token
 from django.views.generic.edit import FormView, UpdateView
 from helpdesk import settings as helpdesk_settings

--- a/helpdesk/views/staff.py
+++ b/helpdesk/views/staff.py
@@ -25,6 +25,8 @@ from django.urls import reverse, reverse_lazy
 from django.utils import timezone
 from django.utils.html import escape
 from django.utils.translation import gettext as _
+from django.utils.dateparse import parse_datetime
+from django.utils.timezone import make_aware
 from django.views.decorators.csrf import requires_csrf_token
 from django.views.generic.edit import FormView, UpdateView
 from helpdesk import settings as helpdesk_settings
@@ -536,12 +538,7 @@ def get_due_date_from_request_or_ticket(
     due_date = request.POST.get('due_date', None) or None
 
     if due_date is not None:
-        # based on Django code to parse dates:
-        # https://docs.djangoproject.com/en/2.0/_modules/django/utils/dateparse/
-        match = DATE_RE.match(due_date)
-        if match:
-            kw = {k: int(v) for k, v in match.groupdict().items()}
-            due_date = date(**kw)
+        due_date = make_aware(parse_datetime(due_date))
     else:
         due_date_year = int(request.POST.get('due_date_year', 0))
         due_date_month = int(request.POST.get('due_date_month', 0))


### PR DESCRIPTION
This change is a patch for issue #1066.  It utilizes the current surrounding architecture and interferes earlier in the process to transform the POST data item into a tz aware datetime object so that no false change is detected upon comparison to the stored due date.

A more thorough fix would involve re-factoring this view to use Django's builtin form handling logic. Probably best to do as part of a larger effort to support I18N and L10N  package-wide.
I don't see any reason this shouldn't work in practice, and have tested it in a variety of scenarios. However, I couldn't think of a good way to add a unit test because the bug is caused by mismatch between client and server side of the application.  It would be good if someone has an idea for a unit test that might help in future with regression testing.
