### PR TITLE
#1069 - make regex for username more permissive for rss_user to match rss_user_queue

### DIFF
--- a/helpdesk/urls.py
+++ b/helpdesk/urls.py
@@ -151,7 +151,7 @@ urlpatterns += [
 
 urlpatterns += [
     re_path(
-        r"^rss/user/(?P<user_name>[a-zA-Z0-9\_\.]+)/",
+        r"^rss/user/(?P<user_name>[^/]+)/",
         helpdesk_staff_member_required(feeds.OpenTicketsByUser()),
         name="rss_user",
     ),


### PR DESCRIPTION
As a simple fix for #1069, matching existing code. This changes the regex for rss_user to match the more permissive regex for rss_user_queue.

This fixes the behaviour seen in #1069, but does not address the problem of django-helpdesk urls being out of date with modern Django url practices using path converters. Since the builtin Django slug converter does not allow "." characters, a custom username converter could be built to allow 
```
re_path(
    r"^rss/user/(?P<user_name>[a-zA-Z0-9\_\.]+)/", 
    helpdesk_staff_member_required(feeds.OpenTicketsByUser()),
    name="rss_user",
),
```

to become:

```
path(
    "rss/user/<username:user_name>/",
    helpdesk_staff_member_required(feeds.OpenTicketsByUser()),
    name="rss_user",
),
```
