### PR TITLE
Enhance email parser to handle multiple multiparts and multiple MIME parts

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ Installation
 `django-helpdesk` requires:
 
 * Python 3.8+
-* Django 3.2 LTS highly recommended (early adopters may test Django 4)
+* Django 3.2 LTS or Django 4.*
 
 You can quickly install the latest stable version of `django-helpdesk`
 app via `pip`::
@@ -72,12 +72,18 @@ Developer Environment
 ---------------------
 
 Follow these steps to set up your development environment to contribute to helpdesk:
+ - check out the helpdesk app to you local file system::
+        git clone https://github.com/django-helpdesk/django-helpdesk.git
+ 
  - install a virtual environment
      - using virtualenv from the helpdesk base folder do::
           virtualenv .venv && source .venv/bin/activate
 
  - install the requirements for development::
     pip install -r requirements.txt -r requirements-dev.txt
+
+To reactivate a VENV just run:
+   source .venv/bin/activate
 
 To see option for the Makefile run: `make`
 

--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,7 @@ Developer Environment
 ---------------------
 
 Follow these steps to set up your development environment to contribute to helpdesk:
- - check out the helpdesk app to you local file system::
+ - check out the helpdesk app to your local file system::
         git clone https://github.com/django-helpdesk/django-helpdesk.git
  
  - install a virtual environment
@@ -81,6 +81,9 @@ Follow these steps to set up your development environment to contribute to helpd
 
  - install the requirements for development::
     pip install -r requirements.txt -r requirements-dev.txt
+
+ - install the requirements for testing as well::
+    pip install -r requirements.txt -r requirements-dev.txt -r requirements-testing.txt
 
 To reactivate a VENV just run:
    source .venv/bin/activate

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -37,7 +37,6 @@ If you want to override the default settings for your users, create ``HELPDESK_D
             'tickets_per_page': 25
             }
 
-
 Generic Options
 ---------------
 These changes are visible throughout django-helpdesk
@@ -85,6 +84,10 @@ These changes are visible throughout django-helpdesk
 - **HELPDESK_MAX_EMAIL_ATTACHMENT_SIZE** Maximum size, in bytes, of file attachments that will be sent via email
 
   **Default:** ``HELPDESK_MAX_EMAIL_ATTACHMENT_SIZE = 512000``
+
+- **VALID_EXTENSIONS** Valid extensions for file types that can be attached to tickets
+
+  **Default:** ``VALID_EXTENSIONS = ['.txt', '.asc', '.htm', '.html', '.pdf', '.doc', '.docx', '.odt', '.jpg', '.png', '.eml']
 
 - **QUEUE_EMAIL_BOX_UPDATE_ONLY** Only process mail with a valid tracking ID; all other mail will be ignored instead of creating a new ticket.
 

--- a/helpdesk/lib.py
+++ b/helpdesk/lib.py
@@ -186,11 +186,11 @@ def format_time_spent(time_spent):
 
 def convert_value(value):
     """ Convert date/time data type to known fixed format string """
-    if type(value) == datetime:
+    if type(value) is datetime:
         return value.strftime(CUSTOMFIELD_DATETIME_FORMAT)
-    elif type(value) == date:
+    elif type(value) is date:
         return value.strftime(CUSTOMFIELD_DATE_FORMAT)
-    elif type(value) == time:
+    elif type(value) is time:
         return value.strftime(CUSTOMFIELD_TIME_FORMAT)
     else:
         return value

--- a/helpdesk/templated_email.py
+++ b/helpdesk/templated_email.py
@@ -97,7 +97,7 @@ def send_templated_mail(template_name,
     if isinstance(recipients, str):
         if recipients.find(','):
             recipients = recipients.split(',')
-    elif type(recipients) != list:
+    elif type(recipients) is not list:
         recipients = [recipients]
 
     msg = EmailMultiAlternatives(subject_part, text_part,

--- a/helpdesk/tests/test_get_email.py
+++ b/helpdesk/tests/test_get_email.py
@@ -7,11 +7,13 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.management import call_command
 from django.shortcuts import get_object_or_404
 from django.test import override_settings, TestCase
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
 import helpdesk.email
-from helpdesk.email import extract_part_data, object_from_message
+from helpdesk.email import extract_email_metadata, process_as_attachment
 from helpdesk.exceptions import DeleteIgnoredTicketException, IgnoreTicketException
 from helpdesk.management.commands.get_email import Command
-from helpdesk.models import Attachment, FollowUp, FollowUpAttachment, IgnoreEmail, Queue, Ticket, TicketCC
+from helpdesk.models import FollowUp, FollowUpAttachment, IgnoreEmail, Queue, Ticket, TicketCC
 from helpdesk.tests import utils
 import itertools
 import logging
@@ -59,7 +61,7 @@ class GetEmailCommonTests(TestCase):
         """
         with open(os.path.join(THIS_DIR, "test_files/blank-body-with-attachment.eml"), encoding="utf-8") as fd:
             test_email = fd.read()
-            ticket = helpdesk.email.object_from_message(
+            ticket = helpdesk.email.extract_email_metadata(
                 test_email, self.queue_public, self.logger)
         # title got truncated because of max_lengh of the model.title field
         assert ticket.title == (
@@ -67,7 +69,7 @@ class GetEmailCommonTests(TestCase):
             "ooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
             "ooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo..."
         )
-        self.assertEqual(ticket.description, "")
+        self.assertEqual(ticket.description, "", msg=ticket.description)
 
     def test_email_with_quoted_printable_body(self):
         """
@@ -75,7 +77,7 @@ class GetEmailCommonTests(TestCase):
         """
         with open(os.path.join(THIS_DIR, "test_files/quoted_printable.eml"), encoding="utf-8") as fd:
             test_email = fd.read()
-            ticket = helpdesk.email.object_from_message(
+            ticket = helpdesk.email.extract_email_metadata(
                 test_email, self.queue_public, self.logger)
         self.assertEqual(ticket.title, "Český test")
         self.assertEqual(ticket.description,
@@ -96,24 +98,29 @@ class GetEmailCommonTests(TestCase):
         """
         with open(os.path.join(THIS_DIR, "test_files/all-special-chars.eml"), encoding="utf-8") as fd:
             test_email = fd.read()
-            ticket = helpdesk.email.object_from_message(
+            ticket = helpdesk.email.extract_email_metadata(
                 test_email, self.queue_public, self.logger)
         self.assertEqual(ticket.title, "Testovácí email")
         self.assertEqual(ticket.description, "íářčšáíéřášč")
 
-    @override_settings(HELPDESK_FULL_FIRST_MESSAGE_FROM_EMAIL=True)
+    @override_settings(HELPDESK_FULL_FIRST_MESSAGE_FROM_EMAIL=False)
     def test_email_with_utf_8_non_decodable_sequences(self):
         """
         Tests that emails with utf-8 non-decodable sequences are parsed correctly
-        The message is fowarded as well
+        The forwarded part of the message must still be in the ticket description if
+        HELPDESK_FULL_FIRST_MESSAGE_FROM_EMAIL is set to True.
+        Otherwise it should only be in the Followup records Comment field
+        NOTE: This test weirdly tests having completely different content in the HTML part
+               than the PLAIN part so not sure about the validity of this as a test but 
+               the code does support this oddity anyway for backwards compatibility
         """
         with open(os.path.join(THIS_DIR, "test_files/utf-nondecodable.eml"), encoding="utf-8") as fd:
             test_email = fd.read()
-        ticket = helpdesk.email.object_from_message(
+        ticket = helpdesk.email.extract_email_metadata(
             test_email, self.queue_public, self.logger)
         self.assertEqual(
             ticket.title, "Fwd: Cyklozaměstnavatel - změna vyhodnocení")
-        self.assertIn("prosazuje lepší", ticket.description)
+        self.assertIn("prosazuje lepší", ticket.description, "Missing text \"prosazuje lepší\" in description: %s" % ticket.description)
         followups = FollowUp.objects.filter(ticket=ticket)
         followup = followups[0]
         attachments = FollowUpAttachment.objects.filter(followup=followup)
@@ -122,21 +129,40 @@ class GetEmailCommonTests(TestCase):
                       attachment.file.read().decode("utf-8"))
 
     @override_settings(HELPDESK_FULL_FIRST_MESSAGE_FROM_EMAIL=True)
-    def test_email_with_forwarded_message(self):
+    def test_email_with_forwarded_message_just_message_stored(self):
         """
-        Forwarded message of that format must be still attached correctly
+        The forwarded part of the message must still be in the ticket description if
+        HELPDESK_FULL_FIRST_MESSAGE_FROM_EMAIL is set to True.
+        Otherwise it should only be in the Followup records Comment field        
         """
         with open(os.path.join(THIS_DIR, "test_files/forwarded-message.eml"), encoding="utf-8") as fd:
             test_email = fd.read()
-        ticket = helpdesk.email.object_from_message(
+        ticket = helpdesk.email.extract_email_metadata(
             test_email, self.queue_public, self.logger)
         self.assertEqual(
             ticket.title, "Test with original message from GitHub")
         self.assertIn("This is email body", ticket.description)
-        assert "Hello there!" not in ticket.description, ticket.description
-        assert FollowUp.objects.filter(ticket=ticket).count() == 1
-        assert "Hello there!" in FollowUp.objects.filter(
-            ticket=ticket).first().comment
+        self.assertTrue("Hello there!" in ticket.description, ticket.description)
+        self.assertTrue(FollowUp.objects.filter(ticket=ticket).count() == 1)
+
+    @override_settings(HELPDESK_FULL_FIRST_MESSAGE_FROM_EMAIL=False)
+    def test_email_with_forwarded_message_chained_messages_stored(self):
+        """
+        The forwarded part of the message must still be in the ticket description if
+        HELPDESK_FULL_FIRST_MESSAGE_FROM_EMAIL is set to True.
+        Otherwise it should only be in the Followup records Comment field        
+        """
+        with open(os.path.join(THIS_DIR, "test_files/forwarded-message.eml"), encoding="utf-8") as fd:
+            test_email = fd.read()
+        ticket = helpdesk.email.extract_email_metadata(
+            test_email, self.queue_public, self.logger)
+        self.assertEqual(
+            ticket.title, "Test with original message from GitHub")
+        self.assertIn("This is email body", ticket.description)
+        self.assertTrue("Hello there!" not in ticket.description, ticket.description)
+        followups = FollowUp.objects.filter(ticket=ticket).values("comment")
+        self.assertTrue(followups.count() == 1)
+        self.assertTrue("Hello there!" in followups[0]["comment"], followups[0]["comment"])
 
     def test_will_delete_ignored_email(self):
         """
@@ -147,7 +173,7 @@ class GetEmailCommonTests(TestCase):
         ignore = IgnoreEmail(name="Test Ignore", email_address=from_meta[1], keep_in_mailbox=False)
         ignore.save()
         with self.assertRaises(DeleteIgnoredTicketException):
-            object_from_message(message.as_string(), self.queue_public, self.logger)
+            extract_email_metadata(message.as_string(), self.queue_public, self.logger)
 
     def test_will_not_delete_ignored_email(self):
         """
@@ -158,7 +184,7 @@ class GetEmailCommonTests(TestCase):
         ignore = IgnoreEmail(name="Test Ignore", email_address=from_meta[1], keep_in_mailbox=True)
         ignore.save()
         with self.assertRaises(IgnoreTicketException):
-            object_from_message(message.as_string(), self.queue_public, self.logger)
+            extract_email_metadata(message.as_string(), self.queue_public, self.logger)
 
     def test_utf8_filename_attachment(self):
         """
@@ -167,7 +193,7 @@ class GetEmailCommonTests(TestCase):
         filename = "TeléfonoMañana.txt"
         part = utils.generate_file_mime_part(locale="es_ES", filename=filename)
         files: typing.List[SimpleUploadedFile] = []
-        extract_part_data(part, counter=1, ticket_id="tst1", files=files, logger=self.logger)
+        process_as_attachment(part, counter=1, files=files, logger=self.logger)
         sent_file: SimpleUploadedFile = files[0]
         # The extractor prepends a part identifier so compare the ending
         self.assertTrue(sent_file.name.endswith(filename), f"Filename extracted does not match: {sent_file.name}")
@@ -179,17 +205,17 @@ class GetEmailCommonTests(TestCase):
         """
         message, _, _ = utils.generate_multipart_email(type_list=['plain', 'image'])
 
-        self.assertEqual(len(mail.outbox), 0)
+        self.assertEqual(len(mail.outbox), 0)  # @UndefinedVariable
 
         with self.assertLogs(logger='helpdesk', level='ERROR') as cm:
-            object_from_message(message.as_string(), self.queue_public, self.logger)
+            extract_email_metadata(message.as_string(), self.queue_public, self.logger)
 
             self.assertIn(
                 "ERROR:helpdesk:['Unsupported file extension: .jpg']",
                 cm.output
             )
 
-        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(len(mail.outbox), 1)  # @UndefinedVariable
         self.assertEqual(f'[test-1] {message.get("subject")} (Opened)', mail.outbox[0].subject)
 
     def test_multiple_attachments(self):
@@ -198,11 +224,11 @@ class GetEmailCommonTests(TestCase):
         """
         message, _, _ = utils.generate_multipart_email(type_list=['plain', 'file', 'image'])
 
-        self.assertEqual(len(mail.outbox), 0)
+        self.assertEqual(len(mail.outbox), 0)  # @UndefinedVariable
 
-        object_from_message(message.as_string(), self.queue_public, self.logger)
+        extract_email_metadata(message.as_string(), self.queue_public, self.logger)
 
-        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(len(mail.outbox), 1)  # @UndefinedVariable
         self.assertEqual(f'[test-1] {message.get("subject")} (Opened)', mail.outbox[0].subject)
 
         ticket = Ticket.objects.get()
@@ -216,10 +242,10 @@ class GetEmailCommonTests(TestCase):
         """
         message, _, _ = utils.generate_multipart_email(type_list=['plain', 'image', 'file', 'image'])
 
-        self.assertEqual(len(mail.outbox), 0)
+        self.assertEqual(len(mail.outbox), 0)  # @UndefinedVariable
 
         with self.assertLogs(logger='helpdesk', level='ERROR') as cm:
-            object_from_message(message.as_string(), self.queue_public, self.logger)
+            extract_email_metadata(message.as_string(), self.queue_public, self.logger)
 
             self.assertIn(
                 "ERROR:helpdesk:['Unsupported file extension: .jpg']",
@@ -240,18 +266,72 @@ class GetEmailCommonTests(TestCase):
         att_content = email_attachment.as_string()
         message.attach(utils.generate_file_mime_part(filename=att_filename, content=att_content))
 
-        object_from_message(message.as_string(), self.queue_public, self.logger)
-
-        self.assertEqual(len(mail.outbox), 1)
+        extract_email_metadata(message.as_string(), self.queue_public, self.logger)
+        self.assertEqual(len(mail.outbox), 1)  # @UndefinedVariable
         self.assertEqual(f'[test-1] {message.get("subject")} (Opened)', mail.outbox[0].subject)
 
         ticket = Ticket.objects.get()
         followup = ticket.followup_set.get()
-        att_retrieved: Attachment = followup.followupattachment_set.get()
-        self.assertTrue(att_retrieved.filename.endswith(att_filename), "Filename of attached multipart not detected: %s" % (att_retrieved.filename))
-        with att_retrieved.file.open('r') as f:
-            retrieved_content = f.read()
-            self.assertEquals(att_content, retrieved_content, "Retrieved attachment content different to original :\n\n%s\n\n%s" % (att_content, retrieved_content))
+
+        for att_retrieved in followup.followupattachment_set.all():
+            if (helpdesk.email.HTML_EMAIL_ATTACHMENT_FILENAME == att_retrieved.filename):
+                # Ignore the HTML formatted conntent of the email that is attached 
+                continue
+            self.assertTrue(att_retrieved.filename.endswith(att_filename), "Filename of attached multipart not detected: %s" % (att_retrieved.filename))
+            with att_retrieved.file.open('r') as f:
+                retrieved_content = f.read()
+                self.assertEquals(att_content, retrieved_content, "Retrieved attachment content different to original :\n\n%s\n\n%s" % (att_content, retrieved_content))
+
+    def test_email_with_inline_and_multipart_as_attachments(self):
+        """
+        Test a multipart email with an inline attachment and a multipart email attachment to the email
+        """
+        inline_att_filename = 'inline_attachment.jpg'
+        email_att_filename = 'email_attachment2.eml'
+        # Create the inline attachment for the email using an ID so we can reference it in the email body
+        inline_image_id = "liTE5er6Dbnd"
+        inline_attachment = utils.generate_image_mime_part(locale="en_US", imagename=inline_att_filename, disposition_primary_type="inline")
+        inline_attachment.add_header('X-Attachment-Id', inline_image_id)
+        inline_attachment.add_header('Content-ID', '<' + inline_image_id + '>')
+        # Create the actual email with its plain and HTML parts
+        email_message = MIMEMultipart(_subtype="alternative")
+        # Create the plain and HTML that will reference the inline attachment
+        plain_body = "Test with inline image: \n[image: " + inline_att_filename + "]\n\n"
+        plain_msg = MIMEText(plain_body)
+        email_message.attach(plain_msg)
+        html_body = '<div><div>Test with inline image: <img src=3D"cid:' + inline_image_id + '" alt=3D="' + inline_att_filename + '"><br></div>'
+        html_msg = MIMEText(html_body, "html")
+        email_message.attach(html_msg)
+        # Create the email attachment and attach that as well
+        email_attachment, _, _ = utils.generate_multipart_email(type_list=['plain', 'html'])
+        email_att_content = email_attachment.as_string()
+        email_message.attach(utils.generate_file_mime_part(filename=email_att_filename, content=email_att_content))
+        # Now create the base multipart and attach all the other parts to it
+        base_message,_ ,_ = utils.generate_multipart_email(type_list=[], sub_type="related")
+        base_message.attach(email_message)
+        base_message.attach(inline_attachment)
+        extract_email_metadata(base_message.as_string(), self.queue_public, self.logger)
+
+        self.assertEqual(len(mail.outbox), 1)  # @UndefinedVariable
+        self.assertEqual(f'[test-1] {base_message.get("subject")} (Opened)', mail.outbox[0].subject)
+
+        ticket = Ticket.objects.get()
+        followup = ticket.followup_set.get()
+        # Check both the inline and attachment are stored as attached files
+        inline_found = False
+        email_attachment_found = False
+        for att_retrieved in followup.followupattachment_set.all():
+            if (helpdesk.email.HTML_EMAIL_ATTACHMENT_FILENAME == att_retrieved.filename):
+                # Ignore the HTML formatted conntent of the email that is attached 
+                continue
+            if att_retrieved.filename.endswith(inline_att_filename):
+                inline_found = True
+            elif  att_retrieved.filename.endswith(email_att_filename):
+                email_attachment_found = True
+            else:
+                self.assertTrue(False, "Unexpected file in ticket attachments: " % att_retrieved.filename)
+        self.assertTrue(email_attachment_found, "Email attachment file not found ticket attachments: %s" % (email_att_filename))
+        self.assertTrue(inline_found, "Inline file not found in email: %s" % (inline_att_filename))
 
         
 class GetEmailParametricTemplate(object):
@@ -424,7 +504,6 @@ class GetEmailParametricTemplate(object):
     def test_commas_in_mail_headers(self):
         """Tests correctly decoding mail headers when a comma is encoded into
            UTF-8. See bug report #832."""
-
         # Create the from using standard RFC required formats
         # Override the last_name to ensure we get a non-ascii character in it
         test_email_from_meta = utils.generate_email_address("fr_FR", last_name_override="Bouissières")
@@ -488,7 +567,6 @@ class GetEmailParametricTemplate(object):
                 mocked_imaplib_server = mock.Mock()
                 mocked_imaplib_server.search = mock.Mock(
                     return_value=imap_mail_list)
-
                 # we ignore the second arg as the data item/mime-part is
                 # constant (RFC822)
                 mocked_imaplib_server.fetch = mock.Mock(
@@ -510,7 +588,6 @@ class GetEmailParametricTemplate(object):
                 mocked_imaplib_server = mock.Mock()
                 mocked_imaplib_server.search = mock.Mock(
                     return_value=imap_mail_list)
-
                 # we ignore the second arg as the data item/mime-part is
                 # constant (RFC822)
                 mocked_imaplib_server.fetch = mock.Mock(
@@ -553,7 +630,6 @@ class GetEmailParametricTemplate(object):
            except this time the email body contains a Django template tag.
            For each email source supported, we mock the backend to provide
            authentically formatted responses containing our test data."""
-
         # example email text from Django docs:
         # https://docs.djangoproject.com/en/1.10/ref/unicode/
         test_email_from = "Arnbjörg Ráðormsdóttir <arnbjorg@example.com>"
@@ -617,7 +693,6 @@ class GetEmailParametricTemplate(object):
                 mocked_imaplib_server = mock.Mock()
                 mocked_imaplib_server.search = mock.Mock(
                     return_value=imap_mail_list)
-
                 # we ignore the second arg as the data item/mime-part is
                 # constant (RFC822)
                 mocked_imaplib_server.fetch = mock.Mock(
@@ -639,7 +714,6 @@ class GetEmailParametricTemplate(object):
                 mocked_imaplib_server = mock.Mock()
                 mocked_imaplib_server.search = mock.Mock(
                     return_value=imap_mail_list)
-
                 # we ignore the second arg as the data item/mime-part is
                 # constant (RFC822)
                 mocked_imaplib_server.fetch = mock.Mock(
@@ -680,12 +754,8 @@ class GetEmailParametricTemplate(object):
            emails from a queue and creating tickets.
            For each email source supported, we mock the backend to provide
            authentically formatted responses containing our test data."""
-
         # example email text from Python docs:
         # https://docs.python.org/3/library/email-examples.html
-        from email.mime.multipart import MIMEMultipart
-        from email.mime.text import MIMEText
-
         me = "my@example.com"
         you = "your@example.com"
         # NOTE: CC'd emails need to be alphabetical and tested as such!
@@ -695,7 +765,6 @@ class GetEmailParametricTemplate(object):
         cc_two = "other@example.com"
         cc = cc_one + ", " + cc_two
         subject = "Link"
-
         # Create message container - the correct MIME type is
         # multipart/alternative.
         msg = MIMEMultipart('alternative')
@@ -703,7 +772,6 @@ class GetEmailParametricTemplate(object):
         msg['From'] = me
         msg['To'] = you
         msg['Cc'] = cc
-
         # Create the body of the message (a plain-text and an HTML version).
         text = "Hi!\nHow are you?\nHere is the link you wanted:\nhttps://www.python.org"
         html = """\
@@ -717,11 +785,9 @@ class GetEmailParametricTemplate(object):
         </body>
         </html>
         """
-
         # Record the MIME types of both parts - text/plain and text/html.
         part1 = MIMEText(text, 'plain')
         part2 = MIMEText(html, 'html')
-
         # Attach parts into message container.
         # According to RFC 2046, the last part of a multipart message, in this case
         # the HTML message, is best and preferred.
@@ -785,7 +851,6 @@ class GetEmailParametricTemplate(object):
                 mocked_imaplib_server = mock.Mock()
                 mocked_imaplib_server.search = mock.Mock(
                     return_value=imap_mail_list)
-
                 # we ignore the second arg as the data item/mime-part is
                 # constant (RFC822)
                 mocked_imaplib_server.fetch = mock.Mock(
@@ -807,7 +872,6 @@ class GetEmailParametricTemplate(object):
                 mocked_imaplib_server = mock.Mock()
                 mocked_imaplib_server.search = mock.Mock(
                     return_value=imap_mail_list)
-
                 # we ignore the second arg as the data item/mime-part is
                 # constant (RFC822)
                 mocked_imaplib_server.fetch = mock.Mock(
@@ -867,7 +931,6 @@ class GetEmailParametricTemplate(object):
     def test_read_pgp_signed_email(self):
         """Tests reading a PGP signed email to ensure we handle base64
            and PGP signatures appropriately."""
-
         # example email text from #567 on GitHub
         with open(os.path.join(THIS_DIR, "test_files/pgp.eml"), encoding="utf-8") as fd:
             test_email = fd.read()
@@ -923,7 +986,6 @@ class GetEmailParametricTemplate(object):
                 mocked_imaplib_server = mock.Mock()
                 mocked_imaplib_server.search = mock.Mock(
                     return_value=imap_mail_list)
-
                 # we ignore the second arg as the data item/mime-part is
                 # constant (RFC822)
                 mocked_imaplib_server.fetch = mock.Mock(
@@ -944,7 +1006,6 @@ class GetEmailParametricTemplate(object):
                 mocked_imaplib_server = mock.Mock()
                 mocked_imaplib_server.search = mock.Mock(
                     return_value=imap_mail_list)
-
                 # we ignore the second arg as the data item/mime-part is
                 # constant (RFC822)
                 mocked_imaplib_server.fetch = mock.Mock(
@@ -1001,8 +1062,6 @@ a9eiiQ+3V1v+7wWHXCzq
 """)
             # should this be 'application/pgp-signature'?
             # self.assertEqual(attach1.mime_type, 'text/plain')
-
-
 class GetEmailCCHandling(TestCase):
     """TestCase that checks CC handling in email. Needs its own test harness."""
 
@@ -1102,7 +1161,6 @@ class GetEmailCCHandling(TestCase):
             ", " + test_email_cc_three + ", " + test_email_cc_four + ", " + ticket_user_emails + \
             "\nFrom: " + test_email_from + "\nSubject: " + \
             test_email_subject + "\n\n" + test_email_body
-        test_mail_len = len(test_email)
 
         with mock.patch('os.listdir') as mocked_listdir, \
                 mock.patch('helpdesk.email.isfile') as mocked_isfile, \

--- a/helpdesk/tests/test_query.py
+++ b/helpdesk/tests/test_query.py
@@ -58,12 +58,13 @@ class QueryTests(TestCase):
         query = query_to_base64({})
         response = self.client.get(
             reverse('helpdesk:datatables_ticket_list', args=[query]))
+        resp_json = response.json()
         self.assertEqual(
-            response.json(),
+            resp_json,
             {
                 "data":
-                [{"ticket": "1 [test_queue-1]", "id": 1, "priority": 3, "title": "unassigned to kbitem", "queue": {"title": "Test queue", "id": 1}, "status": "Open", "created": "now", "due_date": None, "assigned_to": "None", "submitter": None, "row_class": "", "time_spent": "", "kbitem": ""},
-                 {"ticket": "2 [test_queue-2]", "id": 2, "priority": 3, "title": "assigned to kbitem", "queue": {"title": "Test queue", "id": 1}, "status": "Open", "created": "now", "due_date": None, "assigned_to": "None", "submitter": None, "row_class": "", "time_spent": "", "kbitem": "KBItem 1"}],
+                [{"ticket": "1 [test_queue-1]", "id": 1, "priority": 3, "title": "unassigned to kbitem", "queue": {"title": "Test queue", "id": 1}, "status": "Open", "created": resp_json["data"][0]["created"], "due_date": None, "assigned_to": "None", "submitter": None, "row_class": "", "time_spent": "", "kbitem": ""},
+                 {"ticket": "2 [test_queue-2]", "id": 2, "priority": 3, "title": "assigned to kbitem", "queue": {"title": "Test queue", "id": 1}, "status": "Open", "created": resp_json["data"][1]["created"], "due_date": None, "assigned_to": "None", "submitter": None, "row_class": "", "time_spent": "", "kbitem": "KBItem 1"}],
                 "recordsFiltered": 2,
                 "recordsTotal": 2,
                 "draw": 0,
@@ -77,12 +78,13 @@ class QueryTests(TestCase):
         )
         response = self.client.get(
             reverse('helpdesk:datatables_ticket_list', args=[query]))
+        resp_json = response.json()
         self.assertEqual(
-            response.json(),
+            resp_json,
             {
                 "data":
                 [{"ticket": "2 [test_queue-2]", "id": 2, "priority": 3, "title": "assigned to kbitem", "queue": {"title": "Test queue", "id": 1}, "status": "Open",
-                    "created": "now", "due_date": None, "assigned_to": "None", "submitter": None, "row_class": "", "time_spent": "", "kbitem": "KBItem 1"}],
+                    "created": resp_json["data"][0]["created"], "due_date": None, "assigned_to": "None", "submitter": None, "row_class": "", "time_spent": "", "kbitem": "KBItem 1"}],
                 "recordsFiltered": 1,
                 "recordsTotal": 1,
                 "draw": 0,
@@ -96,12 +98,13 @@ class QueryTests(TestCase):
         )
         response = self.client.get(
             reverse('helpdesk:datatables_ticket_list', args=[query]))
+        resp_json = response.json()
         self.assertEqual(
-            response.json(),
+            resp_json,
             {
                 "data":
                 [{"ticket": "2 [test_queue-2]", "id": 2, "priority": 3, "title": "assigned to kbitem", "queue": {"title": "Test queue", "id": 1}, "status": "Open",
-                    "created": "now", "due_date": None, "assigned_to": "None", "submitter": None, "row_class": "", "time_spent": "", "kbitem": "KBItem 1"}],
+                    "created": resp_json["data"][0]["created"], "due_date": None, "assigned_to": "None", "submitter": None, "row_class": "", "time_spent": "", "kbitem": "KBItem 1"}],
                 "recordsFiltered": 1,
                 "recordsTotal": 1,
                 "draw": 0,

--- a/helpdesk/tests/test_ticket_submission.py
+++ b/helpdesk/tests/test_ticket_submission.py
@@ -6,7 +6,7 @@ from django.test import TestCase
 from django.test.client import Client
 from django.urls import reverse
 import email
-from helpdesk.email import object_from_message
+from helpdesk.email import extract_email_metadata
 from helpdesk.models import CustomField, FollowUp, KBCategory, KBItem, Queue, Ticket, TicketCC
 import logging
 from urllib.parse import urlparse
@@ -282,7 +282,7 @@ class EmailInteractionsTestCase(TestCase):
 
         email_count = len(mail.outbox)
 
-        object_from_message(str(msg), self.queue_public, logger=logger)
+        extract_email_metadata(str(msg), self.queue_public, logger=logger)
 
         followup = FollowUp.objects.get(message_id=message_id)
         ticket = Ticket.objects.get(id=followup.ticket.id)
@@ -314,7 +314,7 @@ class EmailInteractionsTestCase(TestCase):
 
         email_count = len(mail.outbox)
 
-        object_from_message(str(msg), self.queue_public, logger=logger)
+        extract_email_metadata(str(msg), self.queue_public, logger=logger)
 
         ticket = Ticket.objects.get(
             title=self.ticket_data['title'], queue=self.queue_public, submitter_email=submitter_email)
@@ -350,7 +350,7 @@ class EmailInteractionsTestCase(TestCase):
 
         email_count = len(mail.outbox)
 
-        object_from_message(str(msg), self.queue_public, logger=logger)
+        extract_email_metadata(str(msg), self.queue_public, logger=logger)
 
         followup = FollowUp.objects.get(message_id=message_id)
         ticket = Ticket.objects.get(id=followup.ticket.id)
@@ -397,7 +397,7 @@ class EmailInteractionsTestCase(TestCase):
 
         email_count = len(mail.outbox)
 
-        object_from_message(str(msg), self.queue_public, logger=logger)
+        extract_email_metadata(str(msg), self.queue_public, logger=logger)
 
         followup = FollowUp.objects.get(message_id=message_id)
         ticket = Ticket.objects.get(id=followup.ticket.id)
@@ -449,7 +449,7 @@ class EmailInteractionsTestCase(TestCase):
 
         email_count = len(mail.outbox)
 
-        object_from_message(str(msg), self.queue_public, logger=logger)
+        extract_email_metadata(str(msg), self.queue_public, logger=logger)
 
         followup = FollowUp.objects.get(message_id=message_id)
         ticket = Ticket.objects.get(id=followup.ticket.id)
@@ -495,7 +495,7 @@ class EmailInteractionsTestCase(TestCase):
 
         email_count = len(mail.outbox)
 
-        object_from_message(str(msg), self.queue_public, logger=logger)
+        extract_email_metadata(str(msg), self.queue_public, logger=logger)
 
         followup = FollowUp.objects.get(message_id=message_id)
         ticket = Ticket.objects.get(id=followup.ticket.id)
@@ -529,7 +529,7 @@ class EmailInteractionsTestCase(TestCase):
         reply.__setitem__('Content-Type', 'text/plain;')
         reply.set_payload(self.ticket_data['description'])
 
-        object_from_message(str(reply), self.queue_public, logger=logger)
+        extract_email_metadata(str(reply), self.queue_public, logger=logger)
 
         followup = FollowUp.objects.get(message_id=message_id)
         ticket = Ticket.objects.get(id=followup.ticket.id)
@@ -585,7 +585,7 @@ class EmailInteractionsTestCase(TestCase):
 
         email_count = len(mail.outbox)
 
-        object_from_message(str(msg), self.queue_public, logger=logger)
+        extract_email_metadata(str(msg), self.queue_public, logger=logger)
 
         followup = FollowUp.objects.get(message_id=message_id)
         ticket = Ticket.objects.get(id=followup.ticket.id)
@@ -629,7 +629,7 @@ class EmailInteractionsTestCase(TestCase):
         reply.__setitem__('Content-Type', 'text/plain;')
         reply.set_payload(self.ticket_data['description'])
 
-        object_from_message(str(reply), self.queue_public, logger=logger)
+        extract_email_metadata(str(reply), self.queue_public, logger=logger)
 
         followup = FollowUp.objects.get(message_id=message_id)
         ticket = Ticket.objects.get(id=followup.ticket.id)
@@ -683,7 +683,7 @@ class EmailInteractionsTestCase(TestCase):
 
         email_count = len(mail.outbox)
 
-        object_from_message(str(msg), self.queue_public, logger=logger)
+        extract_email_metadata(str(msg), self.queue_public, logger=logger)
 
         followup = FollowUp.objects.get(message_id=message_id)
         ticket = Ticket.objects.get(id=followup.ticket.id)
@@ -738,7 +738,7 @@ class EmailInteractionsTestCase(TestCase):
 
         email_count = len(mail.outbox)
 
-        object_from_message(str(reply), self.queue_public, logger=logger)
+        extract_email_metadata(str(reply), self.queue_public, logger=logger)
 
         followup = FollowUp.objects.get(message_id=message_id)
         ticket = Ticket.objects.get(id=followup.ticket.id)
@@ -780,7 +780,7 @@ class EmailInteractionsTestCase(TestCase):
         msg.set_payload(self.ticket_data['description'])
 
         email_count = len(mail.outbox)
-        object_from_message(str(msg), self.queue_public, logger=logger)
+        extract_email_metadata(str(msg), self.queue_public, logger=logger)
 
         followup = FollowUp.objects.get(message_id=message_id)
         ticket = Ticket.objects.get(id=followup.ticket.id)
@@ -830,7 +830,7 @@ class EmailInteractionsTestCase(TestCase):
 
         email_count = len(mail.outbox)
 
-        object_from_message(
+        extract_email_metadata(
             str(msg), self.queue_public_with_notifications_disabled, logger=logger)
 
         followup = FollowUp.objects.get(message_id=message_id)
@@ -877,7 +877,7 @@ class EmailInteractionsTestCase(TestCase):
 
         email_count = len(mail.outbox)
 
-        object_from_message(str(msg), self.queue_public, logger=logger)
+        extract_email_metadata(str(msg), self.queue_public, logger=logger)
 
         followup = FollowUp.objects.get(message_id=message_id)
         ticket = Ticket.objects.get(id=followup.ticket.id)
@@ -915,7 +915,7 @@ class EmailInteractionsTestCase(TestCase):
         reply.__setitem__('Content-Type', 'text/plain;')
         reply.set_payload(self.ticket_data['description'])
 
-        object_from_message(str(reply), self.queue_public, logger=logger)
+        extract_email_metadata(str(reply), self.queue_public, logger=logger)
 
         followup = FollowUp.objects.get(message_id=message_id)
         ticket = Ticket.objects.get(id=followup.ticket.id)
@@ -961,7 +961,7 @@ class EmailInteractionsTestCase(TestCase):
 
         email_count = len(mail.outbox)
 
-        object_from_message(
+        extract_email_metadata(
             str(msg), self.queue_public_with_notifications_disabled, logger=logger)
 
         followup = FollowUp.objects.get(message_id=message_id)
@@ -1000,7 +1000,7 @@ class EmailInteractionsTestCase(TestCase):
         reply.__setitem__('Content-Type', 'text/plain;')
         reply.set_payload(self.ticket_data['description'])
 
-        object_from_message(
+        extract_email_metadata(
             str(reply), self.queue_public_with_notifications_disabled, logger=logger)
 
         followup = FollowUp.objects.get(message_id=message_id)
@@ -1034,7 +1034,7 @@ class EmailInteractionsTestCase(TestCase):
 
         email_count = len(mail.outbox)
 
-        object_from_message(str(msg), self.queue_public, logger=logger)
+        extract_email_metadata(str(msg), self.queue_public, logger=logger)
 
         followup = FollowUp.objects.get(message_id=message_id)
         ticket = Ticket.objects.get(id=followup.ticket.id)
@@ -1056,7 +1056,7 @@ class EmailInteractionsTestCase(TestCase):
         reply.__setitem__('Content-Type', 'text/plain;')
         reply.set_payload(self.ticket_data['description'])
 
-        object_from_message(str(reply), self.queue_public, logger=logger)
+        extract_email_metadata(str(reply), self.queue_public, logger=logger)
 
         followup = FollowUp.objects.get(message_id=message_id)
         ticket = Ticket.objects.get(id=followup.ticket.id)

--- a/helpdesk/tests/test_ticket_submission.py
+++ b/helpdesk/tests/test_ticket_submission.py
@@ -1085,21 +1085,32 @@ class EmailInteractionsTestCase(TestCase):
         cat = KBCategory.objects.create(
             title="Test Cat",
             slug="test_cat",
-            description="This is a test category",
+            description="This is a test category",   
             queue=self.queue_public,
         )
         cat.save()
+        attr_list = {
+            "f1_field_title": "KBItem 1",
+            "f1_attr": "kbitem",
+            "f1_attr_value": "1",
+            "f2_attr": "submitter_email",
+            "f2_attr_value": "foo@bar.cz",
+            "f3_attr": "title",
+            "f3_attr_value": "lol",
+        }
         self.kbitem1 = KBItem.objects.create(
             category=cat,
-            title="KBItem 1",
+            title=attr_list["f1_field_title"],
             question="What?",
             answer="A KB Item",
         )
         self.kbitem1.save()
-        cat_url = reverse('helpdesk:submit') + \
-            "?kbitem=1&submitter_email=foo@bar.cz&title=lol"
+        cat_url = reverse('helpdesk:submit') + '?' \
+            + attr_list["f1_attr"] + '=' + attr_list["f1_attr_value"] + '&' \
+            + attr_list["f2_attr"] + '=' + attr_list["f2_attr_value"] + '&' \
+            + attr_list["f3_attr"] + '=' + attr_list["f3_attr_value"]
         response = self.client.get(cat_url)
-        
+        # Get the rendered response to make it easier to debug if things go wrong
         if (
             hasattr(response, "render")
             and callable(response.render)
@@ -1114,8 +1125,8 @@ class EmailInteractionsTestCase(TestCase):
         
         msg_prefix = content.decode(response.charset)
         self.assertContains(
-            response, '<option value="1" selected>KBItem 1</option>', msg_prefix = msg_prefix)
+            response, '<option value="' + attr_list["f1_attr_value"] + '" selected>' + attr_list["f1_field_title"] + '</option>', msg_prefix = msg_prefix)
         self.assertContains(
-            response, '<input type="email" name="submitter_email" value="foo@bar.cz" class="form-control form-control" required id="id_submitter_email">', msg_prefix = msg_prefix)
+            response, '<input type="email" name="' +  attr_list["f2_attr"] + '" value="' +  attr_list["f2_attr_value"], msg_prefix = msg_prefix)
         self.assertContains(
-            response, '<input type="text" name="title" value="lol" class="form-control form-control" maxlength="100" required id="id_title">', msg_prefix = msg_prefix)
+            response, '<input type="text" name="' +  attr_list["f3_attr"] + '" value="' +  attr_list["f3_attr_value"], msg_prefix = msg_prefix)

--- a/helpdesk/tests/utils.py
+++ b/helpdesk/tests/utils.py
@@ -240,7 +240,7 @@ def generate_multipart_email(locale: str="en_US",
     :param sub_type: multipart sub type that defaults to "mixed" if not specified
     :param use_short_email: produces a "To" or "From" that is only the email address if True
     """    
-    msg = MIMEMultipart(_subtype=sub_type) if sub_type else MIMEMultipart()
+    msg = MIMEMultipart(sub_type) if sub_type else MIMEMultipart()
     for part_type in type_list:
         msg.attach(generate_mime_part(locale=locale, part_type=part_type))
     from_meta, to_meta = add_simple_email_headers(msg, locale=locale, use_short_email=use_short_email)

--- a/helpdesk/tests/utils.py
+++ b/helpdesk/tests/utils.py
@@ -153,21 +153,21 @@ def generate_file_mime_part(locale: str="en_US",filename: str = None, content: s
     encoders.encode_base64(part)
     if not filename:
         filename = get_fake("word", locale=locale, min_length=8) + ".txt"
-    part.add_header('Content-Disposition', "attachment; filename= %s" % filename)
+    part.add_header('Content-Disposition', "attachment; filename=%s" % filename)
     return part
 
-def generate_image_mime_part(locale: str="en_US",imagename: str = None) -> Message:
+def generate_image_mime_part(locale: str="en_US",imagename: str = None, disposition_primary_type: str = "attachment") -> Message:
     """
     
     :param locale: change this to generate locale specific file name and attachment content
     :param filename: pass a file name if you want to specify a specific name otherwise a random name will be generated
     """
     part = MIMEImage(generate_random_image(image_format="JPEG", array_dims=(200, 200)))
-    part.set_payload(get_fake("text", locale=locale, min_length=1024))
+    #part.set_payload(get_fake("text", locale=locale, min_length=1024))
     encoders.encode_base64(part)
     if not imagename:
         imagename = get_fake("word", locale=locale, min_length=8) + ".jpg"
-    part.add_header('Content-Disposition', "attachment; filename= %s" % imagename)
+    part.add_header('Content-Disposition', disposition_primary_type + "; filename= %s" % imagename)
     return part
 
 def generate_email_list(address_cnt: int = 3,
@@ -215,10 +215,10 @@ def generate_mime_part(locale: str="en_US",
     """
     if "plain" == part_type:
         body = get_fake("text", locale=locale, min_length=1024)
-        msg = MIMEText(body)
+        msg = MIMEText(body, part_type)
     elif "html" == part_type:
         body = get_fake_html(locale=locale, wrap_in_body_tag=True)
-        msg = MIMEText(body)
+        msg = MIMEText(body, part_type)
     elif "file" == part_type:
         msg = generate_file_mime_part(locale=locale)
     elif "image" == part_type:
@@ -229,6 +229,7 @@ def generate_mime_part(locale: str="en_US",
 
 def generate_multipart_email(locale: str="en_US",
         type_list: typing.List[str]=["plain", "html", "image"],
+        sub_type: str = None,
         use_short_email: bool=False
         ) -> typing.Tuple[Message, typing.Tuple[str, str], typing.Tuple[str, str]]:
     """
@@ -236,9 +237,10 @@ def generate_multipart_email(locale: str="en_US",
     
     :param locale:
     :param type_list: options are plain, html, image (attachment), file (attachment)
+    :param sub_type: multipart sub type that defaults to "mixed" if not specified
     :param use_short_email: produces a "To" or "From" that is only the email address if True
     """    
-    msg = MIMEMultipart()
+    msg = MIMEMultipart(_subtype=sub_type) if sub_type else MIMEMultipart()
     for part_type in type_list:
         msg.attach(generate_mime_part(locale=locale, part_type=part_type))
     from_meta, to_meta = add_simple_email_headers(msg, locale=locale, use_short_email=use_short_email)


### PR DESCRIPTION
- Rework the email parser to handle multiple attachments including inline in message body and actual attachments to the email.
- Rationalises the code so it is more easily understood what it is doing.
- Fixes various hacks that had accumulated over the years.
- Fixes some flaky tests that are timing dependent.