### PR TITLE
Use SECURE_SSL_REDIRECT as a default value for HELPDESK_USE_HTTPS_IN_EMAIL_LINK setting

### DIFF
--- a/helpdesk/settings.py
+++ b/helpdesk/settings.py
@@ -229,7 +229,7 @@ HELPDESK_ENABLE_PER_QUEUE_STAFF_PERMISSION = getattr(
 
 # use https in the email links
 HELPDESK_USE_HTTPS_IN_EMAIL_LINK = getattr(
-    settings, 'HELPDESK_USE_HTTPS_IN_EMAIL_LINK', False)
+    settings, 'HELPDESK_USE_HTTPS_IN_EMAIL_LINK', settings.SECURE_SSL_REDIRECT)
 
 HELPDESK_TEAMS_MODEL = getattr(
     settings, 'HELPDESK_TEAMS_MODEL', 'pinax_teams.Team')


### PR DESCRIPTION
Following discussion #1115, I believe we could use the setting [SECURE_SSL_REDIRECT](https://docs.djangoproject.com/fr/4.2/ref/settings/#std-setting-SECURE_SSL_REDIRECT) as a way to know if HTTPS has been set up in the project, and thus avoid any surprise in outbound emails.