### PR TITLE
Fixed Sensitive Data Exposure (File permission in attachments)

### DIFF
--- a/helpdesk/models.py
+++ b/helpdesk/models.py
@@ -1144,7 +1144,7 @@ class FollowUpAttachment(Attachment):
         att_path = os.path.join(settings.MEDIA_ROOT, path)
         if settings.DEFAULT_FILE_STORAGE == "django.core.files.storage.FileSystemStorage":
             if not os.path.exists(att_path):
-                os.makedirs(att_path, 0o755)
+                os.makedirs(att_path, helpdesk_settings.HELPDESK_ATTACHMENT_DIR_PERMS)
         return os.path.join(path, filename)
 
 
@@ -1164,7 +1164,7 @@ class KBIAttachment(Attachment):
         att_path = os.path.join(settings.MEDIA_ROOT, path)
         if settings.DEFAULT_FILE_STORAGE == "django.core.files.storage.FileSystemStorage":
             if not os.path.exists(att_path):
-                os.makedirs(att_path, 0o755)
+                os.makedirs(att_path, helpdesk_settings.HELPDESK_ATTACHMENT_DIR_PERMS)
         return os.path.join(path, filename)
 
 

--- a/helpdesk/models.py
+++ b/helpdesk/models.py
@@ -1137,7 +1137,6 @@ class FollowUpAttachment(Attachment):
 
     def attachment_path(self, filename):
 
-        os.umask(0)
         path = 'helpdesk/attachments/{ticket_for_url}-{secret_key}/{id_}'.format(
             ticket_for_url=self.followup.ticket.ticket_for_url,
             secret_key=self.followup.ticket.secret_key,
@@ -1145,7 +1144,7 @@ class FollowUpAttachment(Attachment):
         att_path = os.path.join(settings.MEDIA_ROOT, path)
         if settings.DEFAULT_FILE_STORAGE == "django.core.files.storage.FileSystemStorage":
             if not os.path.exists(att_path):
-                os.makedirs(att_path, 0o777)
+                os.makedirs(att_path, 0o755)
         return os.path.join(path, filename)
 
 
@@ -1159,14 +1158,13 @@ class KBIAttachment(Attachment):
 
     def attachment_path(self, filename):
 
-        os.umask(0)
         path = 'helpdesk/attachments/kb/{category}/{kbi}'.format(
             category=self.kbitem.category,
             kbi=self.kbitem.id)
         att_path = os.path.join(settings.MEDIA_ROOT, path)
         if settings.DEFAULT_FILE_STORAGE == "django.core.files.storage.FileSystemStorage":
             if not os.path.exists(att_path):
-                os.makedirs(att_path, 0o777)
+                os.makedirs(att_path, 0o755)
         return os.path.join(path, filename)
 
 

--- a/helpdesk/settings.py
+++ b/helpdesk/settings.py
@@ -265,3 +265,11 @@ HELPDESK_OAUTH = getattr(
 
 # Set Debug Logging Level for IMAP Services. Default to '0' for No Debugging
 HELPDESK_IMAP_DEBUG_LEVEL = getattr(settings, 'HELPDESK_IMAP_DEBUG_LEVEL', 0)
+
+#############################################
+# file permissions - Attachment directories #
+#############################################
+
+# Attachment directories should be created with permission 755 (rwxr-xr-x)
+# Override it in your own Django settings.py
+HELPDESK_ATTACHMENT_DIR_PERMS = int(getattr(settings, 'HELPDESK_ATTACHMENT_DIR_PERMS', "755"), 8)


### PR DESCRIPTION
This PR is made against https://github.com/django-helpdesk/django-helpdesk/issues/591#issuecomment-1744306396

# Problem Detail

The statement `os.umask(0)` in [models.py](https://github.com/django-helpdesk/django-helpdesk/blob/main/helpdesk/models.py#L1140) line 1140 and 1162 allows files and directories to be created with permission 777 - which is unsafe and leads to CWE-732. Not just that, **after the execution of this code, any files or directories are created with the same `mask`** and leads to permissions like `-rw-rw-rw-` or `drwxrwxrwx` .

Note: Even though the attachment directories are getting created with permission 777, the uploaded files are created with permission 644. Due to of Django's [FILE_UPLOAD_PERMISSIONS](https://docs.djangoproject.com/en/dev/ref/settings/#file-upload-permissions) setting.

## Proof of Concept

A proof-of-concept video has been created. You can find the video [here](https://drive.google.com/file/d/1PhCh8hHWiaweZHWE8_JNIE6zCAFTSEB-/view?usp=sharing) along with the [codebase](https://drive.google.com/file/d/1b1eU-YnIdDQnlTH5uB6JItpCLgIDPp3e/view?usp=sharing). Run the Django project in `django-helpdesk/demo/demodesk`

# Solution
Removing the statement(s) `os.umask(0)` and setting the mode to `755` for method `os.makedirs` in `attachment_path` eliminates the security flaw. A pull request for this fix has been created: 

***

### CLA Requirements:

This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions. All contributed commits are already automatically signed off.

The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin (see [https://developercertificate.org/](https://developercertificate.org/) for more information).

- [Git Commit SignOff documentation](https://developercertificate.org/)

### Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed - to improve global software supply chain security.

The bug is found by running the iCR tool by [OpenRefactory, Inc.](https://openrefactory.com/) and then manually triaging the results.