### PR TITLE
Standalone

### DIFF
--- a/docs/standalone.rst
+++ b/docs/standalone.rst
@@ -107,4 +107,30 @@ To integrate `django-ses`, bindmount a file to `/opt/extra-dependencies.txt` con
 
    django-ses
 
-Ensure to update the `docker.env` file with your necessary secrets.
+Make sure you update the `docker.env` file with the necessary secrets.
+
+
+S3 base attachment support
+---------------------------
+
+Working from the previous SES example we add the following to `local_settings`:
+
+.. code-block:: python
+
+    AWS_S3_REGION_NAME = os.environ.get("AWS_S3_REGION_NAME", "eu-central-1")
+    AWS_STORAGE_BUCKET_NAME = os.environ.get("AWS_STORAGE_BUCKET_NAME", "bitswan-helpdesk-attachments")
+    AWS_QUERYSTRING_AUTH = os.environ.get("AWS_QUERYSTRING_AUTH", True)
+    AWS_QUERYSTRING_EXPIRE = os.environ.get(
+        "AWS_QUERYSTRING_EXPIRE", 60 * 60
+    )
+    AWS_DEFAULT_ACL = "private"
+
+    DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
+
+
+To integrate `django-ses`, bindmount a file to `/opt/extra-dependencies.txt` containing:
+
+.. code-block:: text
+
+   django-storages
+   boto3

--- a/docs/standalone.rst
+++ b/docs/standalone.rst
@@ -89,6 +89,8 @@ An example `local_settings` configuration for utilizing AWS SES for email:
 
 .. code-block:: python
 
+
+   from .settings import *
    import os
 
    DEFAULT_FROM_EMAIL = "support@bitswan.space"

--- a/standalone/Dockerfile
+++ b/standalone/Dockerfile
@@ -4,7 +4,8 @@ RUN apt-get update
 RUN apt-get install -yqq \
    postgresql-common \
    postgresql-client \
-   cron
+   cron \
+   git
 COPY requirements.txt /opt/django-helpdesk/requirements.txt
 COPY standalone/extra-requirements.txt /opt/django-helpdesk/standalone/extra-requirements.txt
 RUN pip3 install -r /opt/django-helpdesk/requirements.txt

--- a/standalone/config/local_settings.py
+++ b/standalone/config/local_settings.py
@@ -1,0 +1,1 @@
+from .settings import *

--- a/standalone/config/local_urls.py
+++ b/standalone/config/local_urls.py
@@ -1,0 +1,2 @@
+local_urlpatterns = [
+]

--- a/standalone/config/settings.py
+++ b/standalone/config/settings.py
@@ -65,7 +65,7 @@ MIDDLEWARE = [
     "whitenoise.middleware.WhiteNoiseMiddleware",
 ]
 
-ROOT_URLCONF = 'demo.demodesk.config.urls'
+ROOT_URLCONF = 'standalone.config.urls'
 
 TEMPLATES = [
     {

--- a/standalone/config/settings.py
+++ b/standalone/config/settings.py
@@ -229,8 +229,3 @@ MEDIA_ROOT = '/data/media'
 
 # for Django 3.2+, set default for autofields:
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
-
-try:
-    from .local_settings import *
-except ImportError:
-    pass

--- a/standalone/config/urls.py
+++ b/standalone/config/urls.py
@@ -1,9 +1,8 @@
+from .local_urls import local_urlpatterns
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import include, path
-from .local_urls import local_urlpatterns
-
 
 
 urlpatterns = [

--- a/standalone/config/urls.py
+++ b/standalone/config/urls.py
@@ -2,10 +2,12 @@ from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import include, path
+from .local_urls import local_urlpatterns
+
 
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('', include('helpdesk.urls', namespace='helpdesk')),
     path('api/auth/', include('rest_framework.urls', namespace='rest_framework'))
-] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT) + local_urlpatterns

--- a/standalone/config/urls.py
+++ b/standalone/config/urls.py
@@ -1,29 +1,8 @@
-"""django-helpdesk demodesk URL Configuration
-
-The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/1.10/topics/http/urls/
-Examples:
-Function views
-    1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  url(r'^$', views.home, name='home')
-Class-based views
-    1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  url(r'^$', Home.as_view(), name='home')
-Including another URLconf
-    1. Import the include() function: from django.conf.urls import url, include
-    2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
-"""
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import include, path
 
-
-# The following uses the static() helper function,
-# which only works when in development mode (using DEBUG).
-# For a real deployment, you'd have to properly configure a media server.
-# For more information, see:
-# https://docs.djangoproject.com/en/1.10/howto/static-files/
 
 urlpatterns = [
     path('admin/', admin.site.urls),

--- a/standalone/config/wsgi.py
+++ b/standalone/config/wsgi.py
@@ -12,6 +12,6 @@ from django.core.wsgi import get_wsgi_application
 import os
 
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "standalone.config.settings")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "standalone.config.local_settings")
 
 application = get_wsgi_application()

--- a/standalone/manage.py
+++ b/standalone/manage.py
@@ -4,7 +4,7 @@ import sys
 
 
 def main():
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "standalone.config.settings")
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "standalone.config.local_settings")
     try:
         from django.core.management import execute_from_command_line
     except ImportError:


### PR DESCRIPTION
I made several mistakes when configuring the standalone app. These range from copypasta issues to ordering the local_settings import order wrong so it was impossible to add new apps to `INSTALLED_APPS` (which can be necessary for setting up SAML/OAuth for example). This PR fixes these mistakes and also adds docs for securely hosting attachments using s3.