### PR TITLE
changed UserSerializer to utilize custom user classes (didn't work wi…

### DIFF
--- a/helpdesk/serializers.py
+++ b/helpdesk/serializers.py
@@ -2,7 +2,7 @@ from .forms import TicketForm
 from .lib import format_time_spent, process_attachments
 from .models import CustomField, FollowUp, FollowUpAttachment, Ticket
 from .user import HelpdeskUser
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from django.contrib.humanize.templatetags import humanize
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
@@ -152,7 +152,7 @@ class UserSerializer(serializers.ModelSerializer):
     password = serializers.CharField(write_only=True)
 
     class Meta:
-        model = User
+        model = get_user_model()
         fields = ('first_name', 'last_name', 'username', 'email', 'password')
 
     def create(self, validated_data):


### PR DESCRIPTION
The `UserSerializer` class under `serializers.py` for REST framework APIs does not work for custom user classes because it was specified only to work with the Django User model. If a custom User class is specified, this can cause an OperationalError given that the table for the Django User model does not exist. I simply updated the code to use `get_user_model()` from the Django auth package so that it always returns an accurate reading of what model is in use for a User type.