### PR TITLE
Fix security problem with update_ticket view

### DIFF
--- a/helpdesk/views/staff.py
+++ b/helpdesk/views/staff.py
@@ -578,7 +578,7 @@ def get_ticket_from_request_with_authorisation(
                 secret_key__iexact=request.POST.get('key')
             )
         except (Ticket.DoesNotExist, ValueError):
-            return redirect_to_login(request.path, 'helpdesk:login')
+            raise PermissionDenied()
 
     return get_object_or_404(Ticket, id=ticket_id)
 
@@ -732,7 +732,10 @@ def get_template_staff_and_template_cc(
 
 def update_ticket(request, ticket_id, public=False):
 
-    ticket = get_ticket_from_request_with_authorisation(request, ticket_id, public)
+    try:
+        ticket = get_ticket_from_request_with_authorisation(request, ticket_id, public)
+    except PermissionDenied:
+        return redirect_to_login(request.path, 'helpdesk:login')
 
     comment = request.POST.get('comment', '')
     new_status = int(request.POST.get('new_status', ticket.status))


### PR DESCRIPTION
This commit:

https://github.com/django-helpdesk/django-helpdesk/commit/ecefd5e407355d41fbacbb028c43d3fbf7f42491#

introduced a security flaw by extracting authentication logic for the update_ticket view to a new function and mixing the return types. This function returns both a Ticket object and a login redirect. This is simply non-sensical and fails to actually login-redirect non-authenticated users.