### PR TITLE
WIP: Fix custom field sending in new ticket webhook

### DIFF
--- a/helpdesk/models.py
+++ b/helpdesk/models.py
@@ -11,6 +11,7 @@ models.py - Model (and hence database) definitions. This is the core of the
 from .lib import convert_value
 from .templated_email import send_templated_mail
 from .validators import validate_file_extension
+from .webhooks import send_new_ticket_webhook
 import datetime
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -664,6 +665,8 @@ class Ticket(models.Model):
         if self.queue.enable_notifications_on_email_events:
             for cc in self.ticketcc_set.all():
                 send('ticket_cc', cc.email_address)
+        if "new_ticket_cc" in roles:
+            send_new_ticket_webhook(self)
         return recipients
 
     def _get_assigned_to(self):

--- a/helpdesk/tests/test_webhooks.py
+++ b/helpdesk/tests/test_webhooks.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.models import User
-from helpdesk.models import Queue
+from helpdesk.models import Queue, CustomField, TicketCustomFieldValue, Ticket
+from helpdesk.serializers import TicketSerializer
 from rest_framework.status import (
     HTTP_201_CREATED
 )
@@ -82,12 +83,16 @@ class WebhookTest(APITestCase):
 
     def setUp(self):
         staff_user = User.objects.create_user(username='test', is_staff=True)
+        CustomField(
+            name="my_custom_field",
+            data_type="varchar",
+            required=False,
+        ).save()
         self.client.force_authenticate(staff_user)
 
     def test_test_server(self):
         server = WebhookServer(('localhost', 8123), WebhookRequestHandler)
         server.start()
-
         requests.post('http://localhost:8123/new-ticket', json={
             "foo": "bar"})
         handled_webhook_requests = requests.get('http://localhost:8123/get-past-requests').json()
@@ -105,8 +110,11 @@ class WebhookTest(APITestCase):
             'title': 'Test title',
             'description': 'Test description\nMulti lines',
             'submitter_email': 'test@mail.com',
-            'priority': 4
+            'priority': 4,
+            'custom_my_custom_field': 'custom value',
         })
+        self.assertEqual(CustomField.objects.all().first().name, "my_custom_field")
+        self.assertEqual(TicketCustomFieldValue.objects.get(ticket=response.data['id']).value, 'custom value')
         self.assertEqual(response.status_code, HTTP_201_CREATED)
         handled_webhook_requests = requests.get('http://localhost:8124/get-past-requests')
         handled_webhook_requests = handled_webhook_requests.json()
@@ -116,6 +124,35 @@ class WebhookTest(APITestCase):
         self.assertEqual(handled_webhook_requests['new_ticket_requests'][-1]["ticket"]["title"], "Test title")
         self.assertEqual(handled_webhook_requests['new_ticket_requests_1'][-1]["ticket"]["title"], "Test title")
         self.assertEqual(handled_webhook_requests['new_ticket_requests'][-1]["ticket"]["description"], "Test description\nMulti lines")
+        ticket = Ticket.objects.get(id=handled_webhook_requests["new_ticket_requests"][-1]["ticket"]["id"])
+        ticket.set_custom_field_values()
+        serializer = TicketSerializer(ticket)
+        self.assertEqual(
+            list(sorted(serializer.fields.keys())),
+            ['assigned_to',
+             'attachment',
+             'custom_my_custom_field',
+             'description',
+             'due_date',
+             'followup_set',
+             'id',
+             'merged_to',
+             'on_hold',
+             'priority',
+             'queue',
+             'resolution',
+             'status',
+             'submitter_email',
+             'title']
+        )
+        with open("/tmp/request", "w") as fd:
+            import json
+            json.dump(handled_webhook_requests['new_ticket_requests_1'][-1]["ticket"], fd, indent=4, default=str)
+        with open("/tmp/serilaizer_data", "w") as fd:
+            import json
+            json.dump(serializer.data, fd, indent=4, default=str)
+
+        self.assertEqual(serializer.data, handled_webhook_requests["new_ticket_requests"][-1]["ticket"])
         response = self.client.post('/api/followups/', {
             'ticket': handled_webhook_requests['new_ticket_requests'][-1]["ticket"]["id"],
             "comment": "Test comment",
@@ -127,6 +164,7 @@ class WebhookTest(APITestCase):
         self.assertEqual(len(handled_webhook_requests['follow_up_requests_1']), 1)
         self.assertEqual(handled_webhook_requests['follow_up_requests'][-1]["ticket"]["followup_set"][-1]["comment"], "Test comment")
         self.assertEqual(handled_webhook_requests['follow_up_requests_1'][-1]["ticket"]["followup_set"][-1]["comment"], "Test comment")
+        
         server.stop()
 
     def test_create_ticket_and_followup_via_email(self):
@@ -206,5 +244,3 @@ class WebhookTest(APITestCase):
         self.assertEqual(handled_webhook_requests['follow_up_requests'][-1]["ticket"]["id"], ticket_id)
 
         server.stop()
-
-


### PR DESCRIPTION
There was a race condition with custom field value object creation where the webhook was being called before the custom values were set in the DB. If anyone has a better idea on how to fix this race then please speak up. This seems to work, but I'm still testing thus the WIP status.
