### PR TITLE
Customization of Ticket PRIORITY_CHOICES in project settings

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -176,6 +176,21 @@ Options that change ticket updates
   **Default:** ``HELPDESK_STAFF_ONLY_TICKET_CC = False``
 
 
+Options that change ticket properties
+-------------------------------------
+
+- **HELPDESK_TICKET_PRIORITY_CHOICES** Customize the priority choices for all tickets.
+
+  The **default** is below::
+
+        HELPDESK_TICKET_PRIORITY_CHOICES = (
+            (1, _('1. Critical')),
+            (2, _('2. High')),
+            (3, _('3. Normal')),
+            (4, _('4. Low')),
+            (5, _('5. Very Low')),
+        )
+
 Staff Ticket Creation Settings
 ------------------------------
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -190,6 +190,17 @@ Options that change ticket properties
             (4, _('4. Low')),
             (5, _('5. Very Low')),
         )
+  If you have a new instance, you may override those settings but if you want to keep previous tickets priorities and add new choices, you may increment integer values like this::
+
+        HELPDESK_TICKET_PRIORITY_CHOICES = (
+            (1, _('1. Critical')),
+            (2, _('2. High')),
+            (3, _('3. Normal')),
+            (4, _('4. Low')),
+            (5, _('5. Very Low')),
+            (6, _('1. Cold')),
+            (7, _('2. Hot')),
+        )
 
 Staff Ticket Creation Settings
 ------------------------------

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -198,8 +198,8 @@ Options that change ticket properties
             (3, _('3. Normal')),
             (4, _('4. Low')),
             (5, _('5. Very Low')),
-            (6, _('1. Cold')),
-            (7, _('2. Hot')),
+            (6, _('6. Cold')),
+            (7, _('7. Hot')),
         )
 
 Staff Ticket Creation Settings

--- a/helpdesk/models.py
+++ b/helpdesk/models.py
@@ -477,13 +477,7 @@ class Ticket(models.Model):
         (DUPLICATE_STATUS, _('Duplicate')),
     )
 
-    PRIORITY_CHOICES = (
-        (1, _('1. Critical')),
-        (2, _('2. High')),
-        (3, _('3. Normal')),
-        (4, _('4. Low')),
-        (5, _('5. Very Low')),
-    )
+    PRIORITY_CHOICES = helpdesk_settings.PRIORITY_CHOICES
 
     title = models.CharField(
         _('Title'),

--- a/helpdesk/models.py
+++ b/helpdesk/models.py
@@ -477,7 +477,7 @@ class Ticket(models.Model):
         (DUPLICATE_STATUS, _('Duplicate')),
     )
 
-    PRIORITY_CHOICES = helpdesk_settings.PRIORITY_CHOICES
+    PRIORITY_CHOICES = helpdesk_settings.TICKET_PRIORITY_CHOICES
 
     title = models.CharField(
         _('Title'),

--- a/helpdesk/settings.py
+++ b/helpdesk/settings.py
@@ -104,16 +104,16 @@ ALLOWED_URL_SCHEMES = getattr(settings, 'ALLOWED_URL_SCHEMES', (
 ))
 
 # Ticket priority choices
-DEFAULT_PRIORITY_CHOICES = (
+DEFAULT_TICKET_PRIORITY_CHOICES = (
     (1, _('1. Critical')),
     (2, _('2. High')),
     (3, _('3. Normal')),
     (4, _('4. Low')),
     (5, _('5. Very Low')),
 )
-PRIORITY_CHOICES = getattr(settings,
-                           'PRIORITY_CHOICES',
-                           DEFAULT_PRIORITY_CHOICES)
+TICKET_PRIORITY_CHOICES = getattr(settings,
+                           'HELPDESK_TICKET_PRIORITY_CHOICES',
+                           DEFAULT_TICKET_PRIORITY_CHOICES)
 
 ############################
 # options for public pages #

--- a/helpdesk/settings.py
+++ b/helpdesk/settings.py
@@ -6,7 +6,7 @@ Default settings for django-helpdesk.
 from django import forms
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.translation import gettext, gettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 import os
 import re
 import warnings

--- a/helpdesk/settings.py
+++ b/helpdesk/settings.py
@@ -6,6 +6,7 @@ Default settings for django-helpdesk.
 from django import forms
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+from django.utils.translation import gettext, gettext_lazy as _
 import os
 import re
 import warnings
@@ -101,6 +102,19 @@ HELPDESK_AUTO_SUBSCRIBE_ON_TICKET_RESPONSE = getattr(settings,
 ALLOWED_URL_SCHEMES = getattr(settings, 'ALLOWED_URL_SCHEMES', (
     'file', 'ftp', 'ftps', 'http', 'https', 'irc', 'mailto', 'sftp', 'ssh', 'tel', 'telnet', 'tftp', 'vnc', 'xmpp',
 ))
+
+# Ticket priority choices
+DEFAULT_PRIORITY_CHOICES = (
+    (1, _('1. Critical')),
+    (2, _('2. High')),
+    (3, _('3. Normal')),
+    (4, _('4. Low')),
+    (5, _('5. Very Low')),
+)
+PRIORITY_CHOICES = getattr(settings,
+                           'PRIORITY_CHOICES',
+                           DEFAULT_PRIORITY_CHOICES)
+
 ############################
 # options for public pages #
 ############################


### PR DESCRIPTION
I wish to have a different set of priorities for tickets.

This is done by adding HELPDESK_TICKET_PRIORITY_CHOICES to the project settings.

If the parameter is not set, it defaults to the official settings.