### PR TITLE
Implement Custom delete_queryset Method in QueueAdmin to Resolve Django 1062 Error

### DIFF
--- a/helpdesk/admin.py
+++ b/helpdesk/admin.py
@@ -37,6 +37,10 @@ class QueueAdmin(admin.ModelAdmin):
         else:
             return "-"
 
+    def delete_queryset(self, request, queryset):
+        for queue in queryset:
+            queue.delete()
+
 
 @admin.register(Ticket)
 class TicketAdmin(admin.ModelAdmin):


### PR DESCRIPTION
This Pull Request implements a custom delete_queryset method within the QueueAdmin class to address the Django 1062 Duplicate Entry error. By individually deleting each Queue instance within a queryset, this method ensures that any custom deletion logic defined in the Queue model's delete method is executed. This approach effectively resolves issues related to the deletion of instances that have unique constraints, thus preventing the Django 1062 error.