### PR TITLE
Time tracking features

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -291,6 +291,13 @@ Options that change ticket properties
             (7, _('7. Hot')),
         )
 
+Time Tracking Options
+---------------------
+
+- **HELPDESK_FOLLOWUP_TIME_SPENT_AUTO** If ``True``, calculate follow-up 'time_spent' with previous follow-up or ticket creation time.
+
+  **Default:** ``HELPDESK_FOLLOWUP_TIME_SPENT_AUTO = False``
+
 Staff Ticket Creation Settings
 ------------------------------
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -327,6 +327,14 @@ Time Tracking Options
                                                          "12-25",
                                                          "12-31",)
 
+- **HELPDESK_FOLLOWUP_TIME_CALCULATION_EXCLUDE_STATUSES** List of ticket statuses to exclude from automatic follow-up 'time_spent' calculation.
+
+  **Default:** ``HELPDESK_FOLLOWUP_TIME_CALCULATION_EXCLUDE_STATUSES = ()``
+  
+  This example will have follow-ups to resolved ticket status not to be counted in::
+
+        HELPDESK_FOLLOWUP_TIME_CALCULATION_EXCLUDE_STATUSES = (HELPDESK_TICKET_RESOLVED_STATUS,)
+
 Staff Ticket Creation Settings
 ------------------------------
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -298,6 +298,26 @@ Time Tracking Options
 
   **Default:** ``HELPDESK_FOLLOWUP_TIME_SPENT_AUTO = False``
 
+- **HELPDESK_FOLLOWUP_TIME_SPENT_OPENING_HOURS** If defined, calculates follow-up 'time_spent' according to open hours.
+
+  **Default:** ``HELPDESK_FOLLOWUP_TIME_SPENT_OPENING_HOURS = {}``
+  
+  If HELPDESK_FOLLOWUP_TIME_SPENT_AUTO is ``True``, you may set open hours to remove off hours from 'time_spent'::
+
+        HELPDESK_FOLLOWUP_TIME_SPENT_OPENING_HOURS = {
+            "monday": (8.5, 19),
+            "tuesday": (8.5, 19),
+            "wednesday": (8.5, 19),
+            "thursday": (8.5, 19),
+            "friday": (8.5, 19),
+            "saturday": (0, 0),
+            "sunday": (0, 0),
+        }
+  
+  Valid hour values must be set between 0 and 23.9999.
+  In this example 8.5 is interpreted as 8:30AM, saturdays and sundays don't count.
+
+
 Staff Ticket Creation Settings
 ------------------------------
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -335,6 +335,14 @@ Time Tracking Options
 
         HELPDESK_FOLLOWUP_TIME_SPENT_EXCLUDE_STATUSES = (HELPDESK_TICKET_RESOLVED_STATUS,)
 
+- **HELPDESK_FOLLOWUP_TIME_SPENT_EXCLUDE_QUEUES** List of ticket queues slugs to exclude from automatic follow-up 'time_spent' calculation.
+
+  **Default:** ``HELPDESK_FOLLOWUP_TIME_SPENT_EXCLUDE_QUEUES = ()``
+  
+  This example will have follow-ups to ticket queue 'time-not-counting-queue' not to be counted in::
+
+        HELPDESK_FOLLOWUP_TIME_SPENT_EXCLUDE_QUEUES = ('time-not-counting-queue',)
+
 Staff Ticket Creation Settings
 ------------------------------
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -299,11 +299,11 @@ Time Tracking Options
   **Default:** ``HELPDESK_FOLLOWUP_TIME_SPENT_AUTO = False``
 
 - **HELPDESK_FOLLOWUP_TIME_SPENT_OPENING_HOURS** If defined, calculates follow-up 'time_spent' according to open hours.
-
+  
   **Default:** ``HELPDESK_FOLLOWUP_TIME_SPENT_OPENING_HOURS = {}``
   
   If HELPDESK_FOLLOWUP_TIME_SPENT_AUTO is ``True``, you may set open hours to remove off hours from 'time_spent'::
-
+  
         HELPDESK_FOLLOWUP_TIME_SPENT_OPENING_HOURS = {
             "monday": (8.5, 19),
             "tuesday": (8.5, 19),
@@ -316,7 +316,16 @@ Time Tracking Options
   
   Valid hour values must be set between 0 and 23.9999.
   In this example 8.5 is interpreted as 8:30AM, saturdays and sundays don't count.
+  
+- **HELPDESK_FOLLOWUP_TIME_SPENT_EXCLUDE_HOLIDAYS** List of days in format "%m-%d" to exclude from automatic follow-up 'time_spent' calculation.
 
+  **Default:** ``HELPDESK_FOLLOWUP_TIME_SPENT_EXCLUDE_HOLIDAYS = ()``
+  
+  This example removes the first and last days of the year together with Christmas::
+
+        HELPDESK_FOLLOWUP_TIME_SPENT_EXCLUDE_HOLIDAYS = ("01-01",
+                                                         "12-25",
+                                                         "12-31",)
 
 Staff Ticket Creation Settings
 ------------------------------

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -321,11 +321,9 @@ Time Tracking Options
 
   **Default:** ``HELPDESK_FOLLOWUP_TIME_SPENT_EXCLUDE_HOLIDAYS = ()``
   
-  This example removes the first and last days of the year together with Christmas::
+  This example removes Christmas and New Year's Eve in 2024::
 
-        HELPDESK_FOLLOWUP_TIME_SPENT_EXCLUDE_HOLIDAYS = ("01-01",
-                                                         "12-25",
-                                                         "12-31",)
+        HELPDESK_FOLLOWUP_TIME_SPENT_EXCLUDE_HOLIDAYS = ("2024-12-25", "2024-12-31",)
 
 - **HELPDESK_FOLLOWUP_TIME_SPENT_EXCLUDE_STATUSES** List of ticket statuses to exclude from automatic follow-up 'time_spent' calculation.
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -327,13 +327,13 @@ Time Tracking Options
                                                          "12-25",
                                                          "12-31",)
 
-- **HELPDESK_FOLLOWUP_TIME_CALCULATION_EXCLUDE_STATUSES** List of ticket statuses to exclude from automatic follow-up 'time_spent' calculation.
+- **HELPDESK_FOLLOWUP_TIME_SPENT_EXCLUDE_STATUSES** List of ticket statuses to exclude from automatic follow-up 'time_spent' calculation.
 
-  **Default:** ``HELPDESK_FOLLOWUP_TIME_CALCULATION_EXCLUDE_STATUSES = ()``
+  **Default:** ``HELPDESK_FOLLOWUP_TIME_SPENT_EXCLUDE_STATUSES = ()``
   
   This example will have follow-ups to resolved ticket status not to be counted in::
 
-        HELPDESK_FOLLOWUP_TIME_CALCULATION_EXCLUDE_STATUSES = (HELPDESK_TICKET_RESOLVED_STATUS,)
+        HELPDESK_FOLLOWUP_TIME_SPENT_EXCLUDE_STATUSES = (HELPDESK_TICKET_RESOLVED_STATUS,)
 
 Staff Ticket Creation Settings
 ------------------------------

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -317,7 +317,7 @@ Time Tracking Options
   Valid hour values must be set between 0 and 23.9999.
   In this example 8.5 is interpreted as 8:30AM, saturdays and sundays don't count.
   
-- **HELPDESK_FOLLOWUP_TIME_SPENT_EXCLUDE_HOLIDAYS** List of days in format "%m-%d" to exclude from automatic follow-up 'time_spent' calculation.
+- **HELPDESK_FOLLOWUP_TIME_SPENT_EXCLUDE_HOLIDAYS** List of days in format "%Y-%m-%d" to exclude from automatic follow-up 'time_spent' calculation.
 
   **Default:** ``HELPDESK_FOLLOWUP_TIME_SPENT_EXCLUDE_HOLIDAYS = ()``
   

--- a/helpdesk/lib.py
+++ b/helpdesk/lib.py
@@ -9,7 +9,7 @@ lib.py - Common functions (eg multipart e-mail)
 
 from datetime import date, datetime, time
 from django.conf import settings
-from django.core.exceptions import ValidationError
+from django.core.exceptions import ValidationError, ImproperlyConfigured
 from django.utils.encoding import smart_str
 from helpdesk.settings import CUSTOMFIELD_DATE_FORMAT, CUSTOMFIELD_DATETIME_FORMAT, CUSTOMFIELD_TIME_FORMAT
 import logging
@@ -206,7 +206,8 @@ def daily_time_spent_calculation(earliest, latest, open_hours):
     MIDNIGHT = 23.9999
     start, end = open_hours.get(weekday, (0, MIDNIGHT))
     if not 0 <= start <= end <= MIDNIGHT:
-        start, end = 0, MIDNIGHT
+        raise ImproperlyConfigured("HELPDESK_FOLLOWUP_TIME_SPENT_OPENING_HOURS"
+                        f" setting for {weekday} out of (0, 23.9999) boundary")
     
     # transform decimals to minutes and seconds
     start_hour, start_minute, start_second = int(start), int(start % 1 * 60), int(start * 60 % 1 * 60)

--- a/helpdesk/lib.py
+++ b/helpdesk/lib.py
@@ -229,5 +229,9 @@ def daily_time_spent_calculation(earliest, latest, open_hours):
     
     day_delta = latest - earliest
 
-    # returns up to 86399 seconds
-    return day_delta.seconds
+    # returns up to 86399 seconds, add one second if full day
+    time_spent_seconds = day_delta.seconds
+    if time_spent_seconds == 86399:
+        time_spent_seconds += 1
+    
+    return time_spent_seconds

--- a/helpdesk/lib.py
+++ b/helpdesk/lib.py
@@ -173,11 +173,10 @@ def format_time_spent(time_spent):
     """Format time_spent attribute to "[H]HHh:MMm" text string to be allign in
     all graphical outputs
     """
-
     if time_spent:
         time_spent = "{0:02d}h:{1:02d}m".format(
-            time_spent.seconds // 3600,
-            time_spent.seconds // 60
+            int(time_spent.total_seconds()) // 3600,
+            int(time_spent.total_seconds()) % 3600 // 60
         )
     else:
         time_spent = ""

--- a/helpdesk/lib.py
+++ b/helpdesk/lib.py
@@ -214,8 +214,8 @@ def daily_time_spent_calculation(earliest, latest, open_hours):
     end_hour, end_minute, end_second = int(end), int(end % 1 * 60), int(end * 60 % 1 * 60)
 
     # translate time for delta calculation
-    earliest_f = earliest.hour + earliest.minute / 60
-    latest_f = latest.hour + latest.minute / 60
+    earliest_f = earliest.hour + earliest.minute / 60 + earliest.second / 3600
+    latest_f = latest.hour + latest.minute / 60 + latest.second / 3600
 
     if earliest_f < start:
         earliest = earliest.replace(hour=start_hour, minute=start_minute, second=start_second)

--- a/helpdesk/lib.py
+++ b/helpdesk/lib.py
@@ -194,3 +194,40 @@ def convert_value(value):
         return value.strftime(CUSTOMFIELD_TIME_FORMAT)
     else:
         return value
+
+
+def daily_time_spent_calculation(earliest, latest, open_hours):
+    """Returns timedelta for a single day time interval according to open hours."""
+
+    # avoid rendering day in different locale
+    weekday = ('monday', 'tuesday', 'wednesday', 'thursday',
+                'friday', 'saturday', 'sunday')[earliest.weekday()]
+    
+    # enforce correct settings
+    MIDNIGHT = 23.9999
+    start, end = open_hours.get(weekday, (0, MIDNIGHT))
+    if not 0 <= start <= end <= MIDNIGHT:
+        start, end = 0, MIDNIGHT
+    
+    # transform decimals to minutes
+    start_hour, start_minute, start_second = int(start), int(start % 1 * 60), int(start * 60 % 1 * 60)
+    end_hour, end_minute, end_second = int(end), int(end % 1 * 60), int(end * 60 % 1 * 60)
+
+    # translate time for delta calculation
+    earliest_f = earliest.hour + earliest.minute / 60
+    latest_f = latest.hour + latest.minute / 60
+
+    if earliest_f < start:
+        earliest = earliest.replace(hour=start_hour, minute=start_minute, second=start_second)
+    elif earliest_f >= end:
+        earliest = earliest.replace(hour=end_hour, minute=end_minute, second=end_second)
+    
+    if latest_f < start:
+        latest = latest.replace(hour=start_hour, minute=start_minute, second=start_second)
+    elif latest_f >= end:
+        latest = latest.replace(hour=end_hour, minute=end_minute, second=end_second)
+    
+    day_delta = latest - earliest
+
+    # returns up to 86399 seconds
+    return day_delta.seconds

--- a/helpdesk/lib.py
+++ b/helpdesk/lib.py
@@ -197,7 +197,7 @@ def convert_value(value):
 
 
 def daily_time_spent_calculation(earliest, latest, open_hours):
-    """Returns timedelta for a single day time interval according to open hours."""
+    """Returns the number of seconds for a single day time interval according to open hours."""
 
     # avoid rendering day in different locale
     weekday = ('monday', 'tuesday', 'wednesday', 'thursday',
@@ -209,7 +209,7 @@ def daily_time_spent_calculation(earliest, latest, open_hours):
     if not 0 <= start <= end <= MIDNIGHT:
         start, end = 0, MIDNIGHT
     
-    # transform decimals to minutes
+    # transform decimals to minutes and seconds
     start_hour, start_minute, start_second = int(start), int(start % 1 * 60), int(start * 60 % 1 * 60)
     end_hour, end_minute, end_second = int(end), int(end % 1 * 60), int(end * 60 % 1 * 60)
 

--- a/helpdesk/models.py
+++ b/helpdesk/models.py
@@ -1000,8 +1000,11 @@ class FollowUp(models.Model):
         return u"%s#followup%s" % (self.ticket.get_absolute_url(), self.id)
 
     def save(self, *args, **kwargs):
+        now = timezone.now()
         t = self.ticket
-        t.modified = timezone.now()
+        if helpdesk_settings.FOLLOWUP_TIME_SPENT_AUTO and not self.time_spent:
+            self.time_spent = now - t.modified
+        t.modified = now
         t.save()
         super(FollowUp, self).save(*args, **kwargs)
 

--- a/helpdesk/models.py
+++ b/helpdesk/models.py
@@ -1026,7 +1026,7 @@ class FollowUp(models.Model):
         time_spent_seconds = 0
         open_hours = helpdesk_settings.FOLLOWUP_TIME_SPENT_OPENING_HOURS
         holidays = helpdesk_settings.FOLLOWUP_TIME_SPENT_EXCLUDE_HOLIDAYS
-        exclude_statuses = helpdesk_settings.FOLLOWUP_TIME_CALCULATION_EXCLUDE_STATUSES
+        exclude_statuses = helpdesk_settings.FOLLOWUP_TIME_SPENT_EXCLUDE_STATUSES
 
         # split time interval by days
         days = latest.toordinal() - earliest.toordinal()

--- a/helpdesk/models.py
+++ b/helpdesk/models.py
@@ -36,8 +36,8 @@ import uuid
 def format_time_spent(time_spent):
     if time_spent:
         time_spent = "{0:02d}h:{1:02d}m".format(
-            time_spent.seconds // 3600,
-            time_spent.seconds % 3600 // 60
+            int(time_spent.total_seconds()) // 3600,
+            int(time_spent.total_seconds()) % 3600 // 60
         )
     else:
         time_spent = ""

--- a/helpdesk/models.py
+++ b/helpdesk/models.py
@@ -1046,7 +1046,7 @@ class FollowUp(models.Model):
                 start_day_time = middle_day_time.replace(hour=0, minute=0, second=0)
                 end_day_time = middle_day_time.replace(hour=23, minute=59, second=59)
             
-            if (start_day_time.strftime("%m-%d") not in holidays and
+            if (start_day_time.strftime("%Y-%m-%d") not in holidays and
                 prev_status not in exclude_statuses and
                 self.ticket.queue.slug not in exclude_queues):
                 time_spent_seconds += daily_time_spent_calculation(start_day_time, end_day_time, open_hours)

--- a/helpdesk/models.py
+++ b/helpdesk/models.py
@@ -1007,16 +1007,17 @@ class FollowUp(models.Model):
     def time_spent_calculation(self):
         "Returns timedelta according to rules settings."
 
-        # extract earliest time from previous follow-up
-        # or ticket creation time
+        # extract parameters from previous follow-up or ticket
         try:
             prev_fup_qs = self.ticket.followup_set.all()
             if self.id:
                 prev_fup_qs = prev_fup_qs.filter(id__lt=self.id)
             prev_fup = prev_fup_qs.latest("date")
             earliest = prev_fup.date
+            prev_status = prev_fup.new_status
         except ObjectDoesNotExist:
             earliest = self.ticket.created
+            prev_status = self.ticket.status
         
         # latest time is current follow-up date
         latest = self.date
@@ -1046,7 +1047,7 @@ class FollowUp(models.Model):
                 end_day_time = middle_day_time.replace(hour=23, minute=59, second=59)
             
             if (start_day_time.strftime("%m-%d") not in holidays and
-                self.ticket.status not in exclude_statuses and
+                prev_status not in exclude_statuses and
                 self.ticket.queue.slug not in exclude_queues):
                 time_spent_seconds += daily_time_spent_calculation(start_day_time, end_day_time, open_hours)
 

--- a/helpdesk/models.py
+++ b/helpdesk/models.py
@@ -1007,16 +1007,24 @@ class FollowUp(models.Model):
     def time_spent_calculation(self):
         "Returns timedelta according to rules settings."
 
-        # extract parameters from previous follow-up or ticket
+        # extract earliest from previous follow-up or ticket
         try:
             prev_fup_qs = self.ticket.followup_set.all()
             if self.id:
                 prev_fup_qs = prev_fup_qs.filter(id__lt=self.id)
             prev_fup = prev_fup_qs.latest("date")
             earliest = prev_fup.date
-            prev_status = prev_fup.new_status
         except ObjectDoesNotExist:
             earliest = self.ticket.created
+
+        # extract previous status from follow-up or ticket
+        try:
+            prev_fup_qs = self.ticket.followup_set.exclude(new_status__isnull=True)
+            if self.id:
+                prev_fup_qs = prev_fup_qs.filter(id__lt=self.id)
+            prev_fup = prev_fup_qs.latest("date")
+            prev_status = prev_fup.new_status
+        except ObjectDoesNotExist:
             prev_status = self.ticket.status
         
         # latest time is current follow-up date

--- a/helpdesk/models.py
+++ b/helpdesk/models.py
@@ -1037,7 +1037,7 @@ class FollowUp(models.Model):
                     start_day_time = latest.replace(hour=0, minute=0, second=0)
                     end_day_time = latest
                 else:
-                    middle_day_time = earliest + timedelta(days=day)
+                    middle_day_time = earliest + datetime.timedelta(days=day)
                     start_day_time = middle_day_time.replace(hour=0, minute=0, second=0)
                     end_day_time = middle_day_time.replace(hour=23, minute=59, second=59)
                 time_spent_seconds += daily_time_spent_calculation(start_day_time, end_day_time, open_hours)

--- a/helpdesk/models.py
+++ b/helpdesk/models.py
@@ -1026,6 +1026,7 @@ class FollowUp(models.Model):
         time_spent_seconds = 0
         open_hours = helpdesk_settings.FOLLOWUP_TIME_SPENT_OPENING_HOURS
         holidays = helpdesk_settings.FOLLOWUP_TIME_SPENT_EXCLUDE_HOLIDAYS
+        exclude_statuses = helpdesk_settings.FOLLOWUP_TIME_CALCULATION_EXCLUDE_STATUSES
 
         # split time interval by days
         days = latest.toordinal() - earliest.toordinal()
@@ -1046,7 +1047,8 @@ class FollowUp(models.Model):
                 end_day_time = middle_day_time.replace(hour=23, minute=59, second=59)
             
             if start_day_time.strftime("%m-%d") not in holidays:
-                time_spent_seconds += daily_time_spent_calculation(start_day_time, end_day_time, open_hours)
+                if self.ticket.status not in exclude_statuses:
+                    time_spent_seconds += daily_time_spent_calculation(start_day_time, end_day_time, open_hours)
 
         return datetime.timedelta(seconds=time_spent_seconds)
 

--- a/helpdesk/models.py
+++ b/helpdesk/models.py
@@ -8,7 +8,7 @@ models.py - Model (and hence database) definitions. This is the core of the
 """
 
 
-from .lib import convert_value, daily_time_spent_calculation
+from .lib import format_time_spent, convert_value, daily_time_spent_calculation
 from .templated_email import send_templated_mail
 from .validators import validate_file_extension
 from .webhooks import send_new_ticket_webhook
@@ -31,17 +31,6 @@ import os
 import re
 from rest_framework import serializers
 import uuid
-
-
-def format_time_spent(time_spent):
-    if time_spent:
-        time_spent = "{0:02d}h:{1:02d}m".format(
-            int(time_spent.total_seconds()) // 3600,
-            int(time_spent.total_seconds()) % 3600 // 60
-        )
-    else:
-        time_spent = ""
-    return time_spent
 
 
 class EscapeHtml(Extension):
@@ -1017,7 +1006,7 @@ class FollowUp(models.Model):
 
     def time_spent_calculation(self):
         "Returns timedelta according to rules settings."
-        
+
         # extract earliest time from previous follow-up
         # or ticket creation time
         try:

--- a/helpdesk/models.py
+++ b/helpdesk/models.py
@@ -1027,6 +1027,7 @@ class FollowUp(models.Model):
         open_hours = helpdesk_settings.FOLLOWUP_TIME_SPENT_OPENING_HOURS
         holidays = helpdesk_settings.FOLLOWUP_TIME_SPENT_EXCLUDE_HOLIDAYS
         exclude_statuses = helpdesk_settings.FOLLOWUP_TIME_SPENT_EXCLUDE_STATUSES
+        exclude_queues = helpdesk_settings.FOLLOWUP_TIME_SPENT_EXCLUDE_QUEUES
 
         # split time interval by days
         days = latest.toordinal() - earliest.toordinal()
@@ -1047,7 +1048,8 @@ class FollowUp(models.Model):
                 end_day_time = middle_day_time.replace(hour=23, minute=59, second=59)
             
             if start_day_time.strftime("%m-%d") not in holidays:
-                if self.ticket.status not in exclude_statuses:
+                if (self.ticket.status not in exclude_statuses and
+                    self.ticket.queue.slug not in exclude_queues):
                     time_spent_seconds += daily_time_spent_calculation(start_day_time, end_day_time, open_hours)
 
         return datetime.timedelta(seconds=time_spent_seconds)

--- a/helpdesk/models.py
+++ b/helpdesk/models.py
@@ -1047,10 +1047,10 @@ class FollowUp(models.Model):
                 start_day_time = middle_day_time.replace(hour=0, minute=0, second=0)
                 end_day_time = middle_day_time.replace(hour=23, minute=59, second=59)
             
-            if start_day_time.strftime("%m-%d") not in holidays:
-                if (self.ticket.status not in exclude_statuses and
-                    self.ticket.queue.slug not in exclude_queues):
-                    time_spent_seconds += daily_time_spent_calculation(start_day_time, end_day_time, open_hours)
+            if (start_day_time.strftime("%m-%d") not in holidays and
+                self.ticket.status not in exclude_statuses and
+                self.ticket.queue.slug not in exclude_queues):
+                time_spent_seconds += daily_time_spent_calculation(start_day_time, end_day_time, open_hours)
 
         return datetime.timedelta(seconds=time_spent_seconds)
 

--- a/helpdesk/models.py
+++ b/helpdesk/models.py
@@ -1003,7 +1003,12 @@ class FollowUp(models.Model):
         now = timezone.now()
         t = self.ticket
         if helpdesk_settings.FOLLOWUP_TIME_SPENT_AUTO and not self.time_spent:
-            self.time_spent = now - t.modified
+            try:
+                latest_fup = t.followup_set.exclude(id=self.id).latest("date")
+                latest_time = latest_fup.date
+            except ObjectDoesNotExist:
+                latest_time = t.created
+            self.time_spent = now - latest_time
         t.modified = now
         t.save()
         super(FollowUp, self).save(*args, **kwargs)

--- a/helpdesk/settings.py
+++ b/helpdesk/settings.py
@@ -176,6 +176,11 @@ FOLLOWUP_TIME_SPENT_EXCLUDE_STATUSES = getattr(settings,
                                    'HELPDESK_FOLLOWUP_TIME_SPENT_EXCLUDE_STATUSES',
                                    ())
 
+# Time doesn't count for listed queues slugs
+FOLLOWUP_TIME_SPENT_EXCLUDE_QUEUES = getattr(settings,
+                                   'HELPDESK_FOLLOWUP_TIME_SPENT_EXCLUDE_QUEUES',
+                                   ())
+
 ############################
 # options for public pages #
 ############################

--- a/helpdesk/settings.py
+++ b/helpdesk/settings.py
@@ -161,6 +161,11 @@ FOLLOWUP_TIME_SPENT_AUTO = getattr(settings,
                                    'HELPDESK_FOLLOWUP_TIME_SPENT_AUTO',
                                    False)
 
+# Calculate time_spent according to open hours
+FOLLOWUP_TIME_SPENT_OPENING_HOURS = getattr(settings,
+                                   'HELPDESK_FOLLOWUP_TIME_SPENT_OPENING_HOURS',
+                                   {})
+
 ############################
 # options for public pages #
 ############################

--- a/helpdesk/settings.py
+++ b/helpdesk/settings.py
@@ -172,8 +172,8 @@ FOLLOWUP_TIME_SPENT_EXCLUDE_HOLIDAYS = getattr(settings,
                                    ())
 
 # Time doesn't count for listed ticket statuses
-FOLLOWUP_TIME_CALCULATION_EXCLUDE_STATUSES = getattr(settings,
-                                   'HELPDESK_FOLLOWUP_TIME_CALCULATION_EXCLUDE_STATUSES',
+FOLLOWUP_TIME_SPENT_EXCLUDE_STATUSES = getattr(settings,
+                                   'HELPDESK_FOLLOWUP_TIME_SPENT_EXCLUDE_STATUSES',
                                    ())
 
 ############################

--- a/helpdesk/settings.py
+++ b/helpdesk/settings.py
@@ -151,6 +151,11 @@ TICKET_PRIORITY_CHOICES = getattr(settings,
                                   'HELPDESK_TICKET_PRIORITY_CHOICES',
                                   DEFAULT_TICKET_PRIORITY_CHOICES)
 
+
+#########################
+# time tracking options #
+#########################
+
 # Follow-ups automatic time_spent calculation
 FOLLOWUP_TIME_SPENT_AUTO = getattr(settings,
                                    'HELPDESK_FOLLOWUP_TIME_SPENT_AUTO',

--- a/helpdesk/settings.py
+++ b/helpdesk/settings.py
@@ -167,8 +167,13 @@ FOLLOWUP_TIME_SPENT_OPENING_HOURS = getattr(settings,
                                    {})
 
 # Holidays don't count for time_spent calculation
-FOLLOWUP_TIME_SPENT_EXCLUDE_HOLIDAYS= getattr(settings,
+FOLLOWUP_TIME_SPENT_EXCLUDE_HOLIDAYS = getattr(settings,
                                    'HELPDESK_FOLLOWUP_TIME_SPENT_EXCLUDE_HOLIDAYS',
+                                   ())
+
+# Time doesn't count for listed ticket statuses
+FOLLOWUP_TIME_CALCULATION_EXCLUDE_STATUSES = getattr(settings,
+                                   'HELPDESK_FOLLOWUP_TIME_CALCULATION_EXCLUDE_STATUSES',
                                    ())
 
 ############################

--- a/helpdesk/settings.py
+++ b/helpdesk/settings.py
@@ -151,6 +151,11 @@ TICKET_PRIORITY_CHOICES = getattr(settings,
                                   'HELPDESK_TICKET_PRIORITY_CHOICES',
                                   DEFAULT_TICKET_PRIORITY_CHOICES)
 
+# Follow-ups automatic time_spent calculation
+FOLLOWUP_TIME_SPENT_AUTO = getattr(settings,
+                                   'HELPDESK_FOLLOWUP_TIME_SPENT_AUTO',
+                                   False)
+
 ############################
 # options for public pages #
 ############################

--- a/helpdesk/settings.py
+++ b/helpdesk/settings.py
@@ -166,6 +166,11 @@ FOLLOWUP_TIME_SPENT_OPENING_HOURS = getattr(settings,
                                    'HELPDESK_FOLLOWUP_TIME_SPENT_OPENING_HOURS',
                                    {})
 
+# Holidays don't count for time_spent calculation
+FOLLOWUP_TIME_SPENT_EXCLUDE_HOLIDAYS= getattr(settings,
+                                   'HELPDESK_FOLLOWUP_TIME_SPENT_EXCLUDE_HOLIDAYS',
+                                   ())
+
 ############################
 # options for public pages #
 ############################


### PR DESCRIPTION
Time spent on ticket follow-ups is manual.

I would like to propose an automatic time calculation feature for follow-ups, introduced in this discussion: https://github.com/django-helpdesk/django-helpdesk/discussions/1158

This is an ongoing PR where I would also like to introduce open hours time calculation rules and exclusions with those parameters:
- HELPDESK_FOLLOWUP_TIME_SPENT_OPENING_HOURS
- HELPDESK_FOLLOWUP_TIME_SPENT_EXCLUDE_HOLIDAYS
- HELPDESK_FOLLOWUP_TIME_SPENT_EXCLUDE_STATUSES
- HELPDESK_FOLLOWUP_TIME_SPENT_EXCLUDE_QUEUES

