### PR TITLE
Allow to track queue change in follow-ups

### DIFF
--- a/helpdesk/templates/helpdesk/ticket.html
+++ b/helpdesk/templates/helpdesk/ticket.html
@@ -151,7 +151,7 @@
                 <dd><select id='id_priority' name='priority'>{% for p in priorities %}{% if p.0 == ticket.priority %}<option value='{{ p.0 }}' selected='selected'>{{ p.1 }}</option>{% else %}<option value='{{ p.0 }}'>{{ p.1 }}</option>{% endif %}{% endfor %}</select></dd>
 
                 <dt><label for='id_queue'>{% trans "Queue" %}</label></dt>
-                <dd><select id='id_queue' name='queue'>{% for q in queues %}{% if q.0 == ticket.queue.id %}<option value='{{ q.0 }}' selected='selected'>{{ q.1 }}</option>{% else %}<option value='{{ q.0 }}'>{{ q.1 }}</option>{% endif %}{% endfor %}</select></dd>
+                <dd><select id='id_queue' name='queue'>{% for queue_id, queue_name in queues %}<option value='{{ queue_id }}'{% if queue_id == ticket.queue.id %} selected{% endif %}>{{ queue_name }}</option>{% endfor %}</select></dd>
 
                 <dt><label for='id_due_date'>{% trans "Due on" %}</label></dt>
                 <dd>{{ form.due_date }}</dd>

--- a/helpdesk/templates/helpdesk/ticket.html
+++ b/helpdesk/templates/helpdesk/ticket.html
@@ -150,6 +150,9 @@
                 <dt><label for='id_priority'>{% trans "Priority" %}</label></dt>
                 <dd><select id='id_priority' name='priority'>{% for p in priorities %}{% if p.0 == ticket.priority %}<option value='{{ p.0 }}' selected='selected'>{{ p.1 }}</option>{% else %}<option value='{{ p.0 }}'>{{ p.1 }}</option>{% endif %}{% endfor %}</select></dd>
 
+                <dt><label for='id_queue'>{% trans "Queue" %}</label></dt>
+                <dd><select id='id_queue' name='queue'>{% for q in queues %}{% if q.0 == ticket.queue.id %}<option value='{{ q.0 }}' selected='selected'>{{ q.1 }}</option>{% else %}<option value='{{ q.0 }}'>{{ q.1 }}</option>{% endif %}{% endfor %}</select></dd>
+
                 <dt><label for='id_due_date'>{% trans "Due on" %}</label></dt>
                 <dd>{{ form.due_date }}</dd>
 

--- a/helpdesk/tests/test_time_spent_auto.py
+++ b/helpdesk/tests/test_time_spent_auto.py
@@ -312,14 +312,14 @@ class TimeSpentAutoTestCase(TestCase):
             response = self.client.post(reverse('helpdesk:update', kwargs={
                                         'ticket_id': ticket.id}), post_data)
             latest_fup = ticket.followup_set.latest('id')
-            latest_fup.date = ticket.created + timedelta(minutes=60 * i)
+            latest_fup.date = ticket.created + timedelta(hours=i)
             latest_fup.time_spent = None
             latest_fup.save()
         
         # total ticket time for followups is 5 hours
         self.assertEqual(latest_fup.date - ticket.created, timedelta(hours=5))
         # calculated time spent with 2 hours exclusion is 3 hours
-        self.assertEqual(ticket.time_spent.total_seconds(), 3 * 3600.0)
+        self.assertEqual(ticket.time_spent.total_seconds(), timedelta(hours=3).total_seconds())
 
         # remove queues exclusion
         helpdesk_settings.FOLLOWUP_TIME_SPENT_EXCLUDE_QUEUES = ()

--- a/helpdesk/tests/test_time_spent_auto.py
+++ b/helpdesk/tests/test_time_spent_auto.py
@@ -2,7 +2,10 @@
 from datetime import datetime, timedelta
 from django.contrib.auth.hashers import make_password
 from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from django.test import TestCase, override_settings
+from django.test.client import Client
+from django.urls import reverse
 from helpdesk.models import FollowUp, Queue, Ticket
 from helpdesk import settings as helpdesk_settings
 import uuid
@@ -32,6 +35,21 @@ class TimeSpentAutoTestCase(TestCase):
             is_superuser=False,
             is_active=True
         )
+
+        self.client = Client()
+
+
+    def loginUser(self, is_staff=True):
+        """Create a staff user and login"""
+        User = get_user_model()
+        self.user = User.objects.create(
+            username='User_1',
+            is_staff=is_staff,
+        )
+        self.user.set_password('pass')
+        self.user.save()
+        self.client.login(username='User_1', password='pass')
+    
 
     def test_add_two_followups_time_spent_auto(self):
         """Tests automatic time_spent calculation."""
@@ -252,3 +270,53 @@ class TimeSpentAutoTestCase(TestCase):
 
         # Remove queues exclusion
         helpdesk_settings.FOLLOWUP_TIME_SPENT_EXCLUDE_QUEUES = ()
+
+    def test_http_followup_time_spent_auto_exclude_queues(self):
+        """Tests automatic time_spent calculation queues exclusion with client"""
+
+        # activate automatic calculation
+        helpdesk_settings.FOLLOWUP_TIME_SPENT_AUTO = True
+        helpdesk_settings.FOLLOWUP_TIME_SPENT_EXCLUDE_QUEUES = ('stop1', 'stop2')
+
+        # make staff user
+        self.loginUser()
+
+        # create queues
+        queues_sequence = ('new', 'stop1', 'resume1', 'stop2', 'resume2', 'end')
+        queues = dict()
+        for slug in queues_sequence:
+            queues[slug] = Queue.objects.create(
+                title=slug,
+                slug=slug,
+            )
+
+        # create ticket
+        initial_data = {
+            'title': 'Queue change ticket test',
+            'queue': queues['new'],
+            'assigned_to': self.user,
+            'status': Ticket.OPEN_STATUS,
+            'created': datetime.strptime('2024-04-09T08:00:00+00:00', "%Y-%m-%dT%H:%M:%S%z")
+        }
+        ticket = Ticket.objects.create(**initial_data)
+
+        # create a change queue follow-up every hour
+        # first follow-up created at the same time of the ticket without queue change
+        # new --1h--> stop1 --0h--> resume1 --1h--> stop2 --0h-->  --1h--> end
+        for (i, queue) in enumerate(queues_sequence):
+            # create follow-up
+            post_data = {
+                'comment': 'ticket in queue {}'.format(queue),
+                'queue': queues[queue].id,
+            }
+            response = self.client.post(reverse('helpdesk:update', kwargs={
+                                        'ticket_id': ticket.id}), post_data)
+            latest_fup = ticket.followup_set.latest('id')
+            latest_fup.date = ticket.created + timedelta(minutes=60 * i)
+            latest_fup.time_spent = None
+            latest_fup.save()
+        
+        # total ticket time for followups is 5 hours
+        self.assertEqual(latest_fup.date - ticket.created, timedelta(hours=5))
+        # calculated time spent with 2 hours exclusion is 3 hours
+        self.assertEqual(ticket.time_spent.total_seconds(), 3 * 3600.0)

--- a/helpdesk/tests/test_time_spent_auto.py
+++ b/helpdesk/tests/test_time_spent_auto.py
@@ -320,3 +320,6 @@ class TimeSpentAutoTestCase(TestCase):
         self.assertEqual(latest_fup.date - ticket.created, timedelta(hours=5))
         # calculated time spent with 2 hours exclusion is 3 hours
         self.assertEqual(ticket.time_spent.total_seconds(), 3 * 3600.0)
+
+        # remove queues exclusion
+        helpdesk_settings.FOLLOWUP_TIME_SPENT_EXCLUDE_QUEUES = ()

--- a/helpdesk/tests/test_time_spent_auto.py
+++ b/helpdesk/tests/test_time_spent_auto.py
@@ -302,7 +302,7 @@ class TimeSpentAutoTestCase(TestCase):
 
         # create a change queue follow-up every hour
         # first follow-up created at the same time of the ticket without queue change
-        # new --1h--> stop1 --0h--> resume1 --1h--> stop2 --0h-->  --1h--> end
+        # new --1h--> stop1 --0h--> resume1 --1h--> stop2 --0h--> resume2 --1h--> end
         for (i, queue) in enumerate(queues_sequence):
             # create follow-up
             post_data = {

--- a/helpdesk/update_ticket.py
+++ b/helpdesk/update_ticket.py
@@ -306,13 +306,11 @@ def update_ticket(
         ticket.priority = priority
 
     if queue != ticket.queue.id:
-        c = TicketChange(
-            followup=f,
+        c = f.ticketchange_set.create(
             field=_('Queue'),
             old_value=ticket.queue.id,
             new_value=queue,
         )
-        c.save()
         ticket.queue_id = queue
 
     if due_date != ticket.due_date:

--- a/helpdesk/update_ticket.py
+++ b/helpdesk/update_ticket.py
@@ -12,6 +12,7 @@ from helpdesk.decorators import (
     is_helpdesk_staff,
 )
 from helpdesk.models import (
+    Queue,
     FollowUp,
     Ticket,
     TicketCC,
@@ -200,6 +201,7 @@ def update_ticket(
         owner=-1,
         ticket_title=None,
         priority=-1,
+        queue=-1,
         new_status=None,
         time_spent=None,
         due_date=None,
@@ -213,6 +215,8 @@ def update_ticket(
         title = ticket.title
     if priority == -1:
         priority = ticket.priority
+    if queue == -1:
+        queue = ticket.queue.id
     if new_status is None:
         new_status = ticket.status
     if new_checklists is None:
@@ -301,6 +305,16 @@ def update_ticket(
         )
         c.save()
         ticket.priority = priority
+
+    if queue != ticket.queue.id:
+        c = TicketChange(
+            followup=f,
+            field=_('Queue'),
+            old_value=ticket.queue.id,
+            new_value=queue,
+        )
+        c.save()
+        ticket.queue.id = queue
 
     if due_date != ticket.due_date:
         c = TicketChange(

--- a/helpdesk/update_ticket.py
+++ b/helpdesk/update_ticket.py
@@ -313,7 +313,7 @@ def update_ticket(
             new_value=queue,
         )
         c.save()
-        ticket.queue.id = queue
+        ticket.queue_id = queue
 
     if due_date != ticket.due_date:
         c = TicketChange(

--- a/helpdesk/update_ticket.py
+++ b/helpdesk/update_ticket.py
@@ -12,7 +12,6 @@ from helpdesk.decorators import (
     is_helpdesk_staff,
 )
 from helpdesk.models import (
-    Queue,
     FollowUp,
     Ticket,
     TicketCC,

--- a/helpdesk/views/staff.py
+++ b/helpdesk/views/staff.py
@@ -428,6 +428,7 @@ def view_ticket(request, ticket_id):
         'form': form,
         'active_users': users,
         'priorities': Ticket.PRIORITY_CHOICES,
+        'queues': queue_choices,
         'preset_replies': PreSetReply.objects.filter(
             Q(queues=ticket.queue) | Q(queues__isnull=True)),
         'ticketcc_string': ticketcc_string,
@@ -566,6 +567,7 @@ def update_ticket_view(request, ticket_id, public=False):
     title = request.POST.get('title', '')
     owner = int(request.POST.get('owner', -1))
     priority = int(request.POST.get('priority', ticket.priority))
+    queue = int(request.POST.get('queue', ticket.queue.id))
 
     # Check if a change happened on checklists
     new_checklists = {}
@@ -589,6 +591,7 @@ def update_ticket_view(request, ticket_id, public=False):
         new_status == ticket.status,
         title == ticket.title,
         priority == int(ticket.priority),
+        queue == int(ticket.queue.id),
         due_date == ticket.due_date,
         (owner == -1) or (not owner and not ticket.assigned_to) or
         (owner and User.objects.get(id=owner) == ticket.assigned_to),
@@ -605,6 +608,7 @@ def update_ticket_view(request, ticket_id, public=False):
         public = request.POST.get('public', False),
         owner = int(request.POST.get('owner', -1)),
         priority = int(request.POST.get('priority', -1)),
+        queue = int(request.POST.get('queue', -1)),
         new_status = new_status,
         time_spent = get_time_spent_from_request(request),
         due_date = get_due_date_from_request_or_ticket(request, ticket),


### PR DESCRIPTION
Because of Time calculation feature that allows for time in specific queues not to be counted in, we need to track queue changes in TicketChanges.

As ticket changes are related to follow-ups, I have added the ability to change ticket queue in the "Change Further Details" of the ticket view.

If this is approved, it will enable me to code correct calculation for the FOLLOWUP_TIME_SPENT_EXCLUDE_QUEUES setting.

In my use case, queues are used to pass tickets to different teams.