### PR TITLE
Emit a signal when a ticket is updated

### DIFF
--- a/docs/webhooks.rst
+++ b/docs/webhooks.rst
@@ -17,13 +17,14 @@ Signals
 
 Webhooks are triggered through django signals.
 
-The two existing signals are:
+The two available signals are:
   - new_ticket_done
   - update_ticket_done
 
 You have the opportunity to listen to those in your project if you have post processing workflows outside of webhooks::
 
-
+  
+  from django.dispatch import receiver
   from helpdesk.signals import new_ticket_done, update_ticket_done
   
   @receiver(new_ticket_done)

--- a/docs/webhooks.rst
+++ b/docs/webhooks.rst
@@ -10,3 +10,29 @@ You can register webhooks to allow third party apps to be notified of helpdesk e
 3. You can optionally set ``HELPDESK_WEBHOOK_TIMEOUT`` which defaults to 3 seconds. Warning, however, webhook requests are sent out sychronously on ticket update. If your webhook handling server is too slow, you should fix this rather than causing helpdesk freezes by messing with this variable.
 
 Once these URLs are configured, a serialized copy of the ticket object will be posted to each of these URLs each time a ticket is created or followed up on respectively.
+
+
+Django signals
+--------------
+
+Webhooks are triggered through signals emitted for new tickets creation and ticket follow-up updates.
+
+The two existing signals are:
+  - new_ticket_done
+  - update_ticket_done
+
+You have the opportunity to listen to those in your project if you have post processing workflows outside of webhooks.
+
+```
+from helpdesk.signals import new_ticket_done, update_ticket_done
+
+@receiver(new_ticket_done)
+def process_new_ticket(sender, ticket, **kwargs):
+    "Triggers this code when a ticket is created."
+    pass
+    
+@receiver(update_ticket_done)
+def process_followup_update(sender, followup, **kwargs):
+    "Triggers this code when a follow-up is created."
+    pass
+```

--- a/docs/webhooks.rst
+++ b/docs/webhooks.rst
@@ -12,27 +12,26 @@ You can register webhooks to allow third party apps to be notified of helpdesk e
 Once these URLs are configured, a serialized copy of the ticket object will be posted to each of these URLs each time a ticket is created or followed up on respectively.
 
 
-Django signals
+Signals
 --------------
 
-Webhooks are triggered through signals emitted for new tickets creation and ticket follow-up updates.
+Webhooks are triggered through django signals.
 
 The two existing signals are:
   - new_ticket_done
   - update_ticket_done
 
-You have the opportunity to listen to those in your project if you have post processing workflows outside of webhooks.
+You have the opportunity to listen to those in your project if you have post processing workflows outside of webhooks::
 
-```
-from helpdesk.signals import new_ticket_done, update_ticket_done
 
-@receiver(new_ticket_done)
-def process_new_ticket(sender, ticket, **kwargs):
-    "Triggers this code when a ticket is created."
-    pass
-    
-@receiver(update_ticket_done)
-def process_followup_update(sender, followup, **kwargs):
-    "Triggers this code when a follow-up is created."
-    pass
-```
+  from helpdesk.signals import new_ticket_done, update_ticket_done
+  
+  @receiver(new_ticket_done)
+  def process_new_ticket(sender, ticket, **kwargs):
+      "Triggers this code when a ticket is created."
+      pass
+      
+  @receiver(update_ticket_done)
+  def process_followup_update(sender, followup, **kwargs):
+      "Triggers this code when a follow-up is created."
+      pass

--- a/docs/webhooks.rst
+++ b/docs/webhooks.rst
@@ -15,7 +15,7 @@ Once these URLs are configured, a serialized copy of the ticket object will be p
 Signals
 --------------
 
-Webhooks are triggered through django signals.
+Webhooks are triggered through `Django Signals <https://docs.djangoproject.com/en/stable/topics/signals/>_`.
 
 The two available signals are:
   - new_ticket_done

--- a/helpdesk/email.py
+++ b/helpdesk/email.py
@@ -25,6 +25,7 @@ from helpdesk import webhooks
 from helpdesk.exceptions import DeleteIgnoredTicketException, IgnoreTicketException
 from helpdesk.lib import process_attachments, safe_template_context
 from helpdesk.models import FollowUp, IgnoreEmail, Queue, Ticket
+from helpdesk.signals import update_ticket_done
 import imaplib
 import logging
 import mimetypes
@@ -618,7 +619,8 @@ def create_object_from_email_message(message, ticket_id, payload, files, logger)
     else:
         send_info_email(message_id, f, ticket, context, queue, new)
     if not new:
-        webhooks.notify_followup_webhooks(f)
+        # emit signal with followup when the ticket is updated
+        update_ticket_done.send(sender="create_object_from_email_message", followup=f)
     return ticket
 
 

--- a/helpdesk/email.py
+++ b/helpdesk/email.py
@@ -618,7 +618,7 @@ def create_object_from_email_message(message, ticket_id, payload, files, logger)
     else:
         send_info_email(message_id, f, ticket, context, queue, new)
     if new:
-        # emit signal when the PublicTicketForm.save is done
+        # emit signal when a new ticket is created
         new_ticket_done.send(sender="create_object_from_email_message", ticket=ticket)
     else:
         # emit signal with followup when the ticket is updated

--- a/helpdesk/email.py
+++ b/helpdesk/email.py
@@ -21,7 +21,6 @@ from email.message import EmailMessage, MIMEPart
 from email.utils import getaddresses
 from email_reply_parser import EmailReplyParser
 from helpdesk import settings
-from helpdesk import webhooks
 from helpdesk.exceptions import DeleteIgnoredTicketException, IgnoreTicketException
 from helpdesk.lib import process_attachments, safe_template_context
 from helpdesk.models import FollowUp, IgnoreEmail, Queue, Ticket

--- a/helpdesk/email.py
+++ b/helpdesk/email.py
@@ -24,7 +24,7 @@ from helpdesk import settings
 from helpdesk.exceptions import DeleteIgnoredTicketException, IgnoreTicketException
 from helpdesk.lib import process_attachments, safe_template_context
 from helpdesk.models import FollowUp, IgnoreEmail, Queue, Ticket
-from helpdesk.signals import update_ticket_done
+from helpdesk.signals import new_ticket_done, update_ticket_done
 import imaplib
 import logging
 import mimetypes
@@ -617,7 +617,10 @@ def create_object_from_email_message(message, ticket_id, payload, files, logger)
             "Message seems to be auto-reply, not sending any emails back to the sender")
     else:
         send_info_email(message_id, f, ticket, context, queue, new)
-    if not new:
+    if new:
+        # emit signal when the PublicTicketForm.save is done
+        new_ticket_done.send(sender="create_object_from_email_message", ticket=ticket)
+    else:
         # emit signal with followup when the ticket is updated
         update_ticket_done.send(sender="create_object_from_email_message", followup=f)
     return ticket

--- a/helpdesk/forms.py
+++ b/helpdesk/forms.py
@@ -36,6 +36,7 @@ from helpdesk.settings import (
     CUSTOMFIELD_TO_FIELD_DICT
 )
 from helpdesk.validators import validate_file_extension
+from helpdesk.signals import new_ticket_done
 import logging
 
 
@@ -418,6 +419,10 @@ class TicketForm(AbstractTicketForm):
         followup.save()
 
         files = self._attach_files_to_follow_up(followup)
+
+        # emit signal when the TicketForm.save is done
+        new_ticket_done.send(sender="TicketForm", ticket=ticket)
+
         self._send_messages(ticket=ticket,
                             queue=queue,
                             followup=followup,
@@ -507,6 +512,10 @@ class PublicTicketForm(AbstractTicketForm):
         followup.save()
 
         files = self._attach_files_to_follow_up(followup)
+
+        # emit signal when the PublicTicketForm.save is done
+        new_ticket_done.send(sender="PublicTicketForm", ticket=ticket)
+
         self._send_messages(ticket=ticket,
                             queue=queue,
                             followup=followup,

--- a/helpdesk/models.py
+++ b/helpdesk/models.py
@@ -11,7 +11,6 @@ models.py - Model (and hence database) definitions. This is the core of the
 from .lib import format_time_spent, convert_value, daily_time_spent_calculation
 from .templated_email import send_templated_mail
 from .validators import validate_file_extension
-from .webhooks import send_new_ticket_webhook
 import datetime
 from django.conf import settings
 from django.contrib.auth import get_user_model

--- a/helpdesk/models.py
+++ b/helpdesk/models.py
@@ -644,8 +644,6 @@ class Ticket(models.Model):
         if self.queue.enable_notifications_on_email_events:
             for cc in self.ticketcc_set.all():
                 send('ticket_cc', cc.email_address)
-        if "new_ticket_cc" in roles:
-            send_new_ticket_webhook(self)
         return recipients
 
     def _get_assigned_to(self):

--- a/helpdesk/signals.py
+++ b/helpdesk/signals.py
@@ -1,4 +1,7 @@
 import django.dispatch
 
-# create a signal for ticket updates
+# create a signal for *TicketForm
+new_ticket_done = django.dispatch.Signal()
+
+# create a signal for ticket_update view
 update_ticket_done = django.dispatch.Signal()

--- a/helpdesk/signals.py
+++ b/helpdesk/signals.py
@@ -1,0 +1,4 @@
+import django.dispatch
+
+# create a signal for ticket updates
+update_ticket_done = django.dispatch.Signal()

--- a/helpdesk/update_ticket.py
+++ b/helpdesk/update_ticket.py
@@ -268,41 +268,33 @@ def update_ticket(
     files = process_attachments(f, files) if files else []
 
     if ticket_title and ticket_title != ticket.title:
-        c = TicketChange(
-            followup=f,
+        c = f.ticketchange_set.create(
             field=_('Title'),
             old_value=ticket.title,
             new_value=ticket_title,
         )
-        c.save()
         ticket.title = ticket_title
 
     if new_status != old_status:
-        c = TicketChange(
-            followup=f,
+        c = f.ticketchange_set.create(
             field=_('Status'),
             old_value=old_status_str,
             new_value=ticket.get_status_display(),
         )
-        c.save()
 
     if ticket.assigned_to != old_owner:
-        c = TicketChange(
-            followup=f,
+        c = f.ticketchange_set.create(
             field=_('Owner'),
             old_value=old_owner,
             new_value=ticket.assigned_to,
         )
-        c.save()
 
     if priority != ticket.priority:
-        c = TicketChange(
-            followup=f,
+        c = f.ticketchange_set.create(
             field=_('Priority'),
             old_value=ticket.priority,
             new_value=priority,
         )
-        c.save()
         ticket.priority = priority
 
     if queue != ticket.queue.id:
@@ -314,13 +306,11 @@ def update_ticket(
         ticket.queue_id = queue
 
     if due_date != ticket.due_date:
-        c = TicketChange(
-            followup=f,
+        c = f.ticketchange_set.create(
             field=_('Due on'),
             old_value=ticket.due_date,
             new_value=due_date,
         )
-        c.save()
         ticket.due_date = due_date
 
     for checklist in ticket.checklists.all():

--- a/helpdesk/update_ticket.py
+++ b/helpdesk/update_ticket.py
@@ -15,7 +15,6 @@ from helpdesk.models import (
     FollowUp,
     Ticket,
     TicketCC,
-    TicketChange,
 )
 from helpdesk.signals import update_ticket_done
 

--- a/helpdesk/webhooks.py
+++ b/helpdesk/webhooks.py
@@ -36,8 +36,7 @@ def notify_followup_webhooks(followup):
 # listener is loaded via app.py HelpdeskConfig.ready()
 @receiver(update_ticket_done)
 def notify_followup_webhooks_receiver(sender, followup, **kwargs):
-    if sender == "update_ticket":
-        notify_followup_webhooks(followup)
+    notify_followup_webhooks(followup)
 
 
 def send_new_ticket_webhook(ticket):

--- a/helpdesk/webhooks.py
+++ b/helpdesk/webhooks.py
@@ -4,7 +4,7 @@ import logging
 from django.dispatch import receiver
 
 from . import settings
-from .signals import update_ticket_done
+from .signals import new_ticket_done, update_ticket_done
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +32,6 @@ def notify_followup_webhooks(followup):
         except requests.exceptions.Timeout:
             logger.error('Timeout while sending followup webhook to %s', url)
 
-
 # listener is loaded via app.py HelpdeskConfig.ready()
 @receiver(update_ticket_done)
 def notify_followup_webhooks_receiver(sender, followup, **kwargs):
@@ -59,3 +58,8 @@ def send_new_ticket_webhook(ticket):
             requests.post(url, json=data, timeout=settings.HELPDESK_WEBHOOK_TIMEOUT)
         except requests.exceptions.Timeout:
             logger.error('Timeout while sending new ticket webhook to %s', url)
+
+# listener is loaded via app.py HelpdeskConfig.ready()
+@receiver(new_ticket_done)
+def send_new_ticket_webhook_receiver(sender, ticket, **kwargs):
+    send_new_ticket_webhook(ticket)

--- a/helpdesk/webhooks.py
+++ b/helpdesk/webhooks.py
@@ -1,33 +1,38 @@
-from . import settings
-
 import requests
 import requests.exceptions
 import logging
 
+from . import settings
+from .signals import update_ticket_done
+
 logger = logging.getLogger(__name__)
 
-def notify_followup_webhooks(followup):
+# listener is loaded via app.py HelpdeskConfig.ready()
+@receiver(update_ticket_done)
+def notify_followup_webhooks(sender, followup, **kwargs):
     urls = settings.HELPDESK_GET_FOLLOWUP_WEBHOOK_URLS()
     if not urls:
         return
-    # Serialize the ticket associated with the followup
-    from .serializers import TicketSerializer
-    ticket = followup.ticket
-    ticket.set_custom_field_values()
-    serialized_ticket = TicketSerializer(ticket).data
 
-    # Prepare the data to send
-    data = {
-        'ticket': serialized_ticket,
-        'queue_slug': ticket.queue.slug,
-        'followup_id': followup.id
-    }
+    if sender == "update_ticket":
+        # Serialize the ticket associated with the followup
+        from .serializers import TicketSerializer
+        ticket = followup.ticket
+        ticket.set_custom_field_values()
+        serialized_ticket = TicketSerializer(ticket).data
 
-    for url in urls:
-        try:
-            requests.post(url, json=data, timeout=settings.HELPDESK_WEBHOOK_TIMEOUT)
-        except requests.exceptions.Timeout:
-            logger.error('Timeout while sending followup webhook to %s', url)
+        # Prepare the data to send
+        data = {
+            'ticket': serialized_ticket,
+            'queue_slug': ticket.queue.slug,
+            'followup_id': followup.id
+        }
+
+        for url in urls:
+            try:
+                requests.post(url, json=data, timeout=settings.HELPDESK_WEBHOOK_TIMEOUT)
+            except requests.exceptions.Timeout:
+                logger.error('Timeout while sending followup webhook to %s', url)
 
 
 def send_new_ticket_webhook(ticket):

--- a/helpdesk/webhooks.py
+++ b/helpdesk/webhooks.py
@@ -8,32 +8,36 @@ from .signals import update_ticket_done
 
 logger = logging.getLogger(__name__)
 
-# listener is loaded via app.py HelpdeskConfig.ready()
-@receiver(update_ticket_done)
-def notify_followup_webhooks(sender, followup, **kwargs):
+def notify_followup_webhooks(followup):
     urls = settings.HELPDESK_GET_FOLLOWUP_WEBHOOK_URLS()
     if not urls:
         return
 
+    # Serialize the ticket associated with the followup
+    from .serializers import TicketSerializer
+    ticket = followup.ticket
+    ticket.set_custom_field_values()
+    serialized_ticket = TicketSerializer(ticket).data
+
+    # Prepare the data to send
+    data = {
+        'ticket': serialized_ticket,
+        'queue_slug': ticket.queue.slug,
+        'followup_id': followup.id
+    }
+
+    for url in urls:
+        try:
+            requests.post(url, json=data, timeout=settings.HELPDESK_WEBHOOK_TIMEOUT)
+        except requests.exceptions.Timeout:
+            logger.error('Timeout while sending followup webhook to %s', url)
+
+
+# listener is loaded via app.py HelpdeskConfig.ready()
+@receiver(update_ticket_done)
+def notify_followup_webhooks_receiver(sender, followup, **kwargs):
     if sender == "update_ticket":
-        # Serialize the ticket associated with the followup
-        from .serializers import TicketSerializer
-        ticket = followup.ticket
-        ticket.set_custom_field_values()
-        serialized_ticket = TicketSerializer(ticket).data
-
-        # Prepare the data to send
-        data = {
-            'ticket': serialized_ticket,
-            'queue_slug': ticket.queue.slug,
-            'followup_id': followup.id
-        }
-
-        for url in urls:
-            try:
-                requests.post(url, json=data, timeout=settings.HELPDESK_WEBHOOK_TIMEOUT)
-            except requests.exceptions.Timeout:
-                logger.error('Timeout while sending followup webhook to %s', url)
+        notify_followup_webhooks(followup)
 
 
 def send_new_ticket_webhook(ticket):

--- a/helpdesk/webhooks.py
+++ b/helpdesk/webhooks.py
@@ -1,6 +1,7 @@
 import requests
 import requests.exceptions
 import logging
+from django.dispatch import receiver
 
 from . import settings
 from .signals import update_ticket_done


### PR DESCRIPTION
I have a use case where I need to follow the modifications of the tickets.

I unfortunately cannot hook to the post_save signal of the FollowUp model because at this time, the TicketChange and Ticket models are not updated yet with new data.

Someone added the `notify_followup_webhooks` function to `update_ticket` for a similar purpose.

In this PR, I propose to have the update_ticket function emit a signal when its process is done.
This way, anyone can hook post processing workflows outside of helpdesk.

Not to have duplicate code logic, I move the notify_followup_webhooks outside of update_ticket and have it listen to the ticket_update_done signal the same way someone would do it outside of helpdesk. 