### PR TITLE
FIX: replace hardcoded urls with Django generated ones. Fixes #1171

### DIFF
--- a/helpdesk/templates/helpdesk/my_tickets.html
+++ b/helpdesk/templates/helpdesk/my_tickets.html
@@ -37,7 +37,9 @@ window.addEventListener('load', function()
             data.results.forEach(function(ticket) {
                 $('#ticketsTable tbody').append(`
                     <tr>
-                        <td><a href="/view/?ticket=${ticket.id}&email=${ticket.submitter}&key=${ticket.secret_key}">${ticket.title}</a></td>
+                        <td>
+                            <a href='{% url "helpdesk:public_view" %}?ticket=${ticket.id}&email=${ticket.submitter}&key=${ticket.secret_key}'>${ticket.title}</a>
+                        </td>
                         <td>${ticket.queue.title}</td>
                         <td>${ticket.status}</td>
                         <td>${ticket.created}</td>

--- a/helpdesk/templates/helpdesk/public_view_ticket.html
+++ b/helpdesk/templates/helpdesk/public_view_ticket.html
@@ -103,7 +103,10 @@
 
         <dt><label for='commentBox'>{% trans "Comment / Resolution" %}</label></dt>
         <dd><textarea rows='8' cols='70' name='comment' id='commentBox'></textarea></dd>
-        <dd class='form_help_text'>{% trans "You can insert ticket and queue details in your message. For more information, see the <a href='../../help/context/'>context help page</a>." %}</dd>
+	{% url "helpdesk:help_context" as context_help_url %}
+	{% blocktrans %}
+        <dd class='form_help_text'>You can insert ticket and queue details in your message. For more information, see the <a href='{{ context_help_url }}'>context help page</a>.</dd>
+	{% endblocktrans %}
 
         {% if not ticket.can_be_resolved %}<dd>{% trans "This ticket cannot be resolved or closed until the tickets it depends on are resolved." %}</dd>{% endif %}
         {% if ticket.status == 1 %}

--- a/helpdesk/templates/helpdesk/ticket.html
+++ b/helpdesk/templates/helpdesk/ticket.html
@@ -105,7 +105,10 @@
 
                 <dt><label for='commentBox'>{% trans "Comment / Resolution" %}</label></dt>
                 <dd><textarea rows='8' cols='70' name='comment' id='commentBox'></textarea></dd>
-                <dd class='form_help_text'>{% trans "You can insert ticket and queue details in your message. For more information, see the <a href='../../help/context/'>context help page</a>." %}</dd>
+		{% url "helpdesk:help_context" as context_help_url %}
+		{% blocktrans %}
+		<dd class='form_help_text'>You can insert ticket and queue details in your message. For more information, see the <a href='{{ context_help_url }}'>context help page</a>.</dd>
+		{% endblocktrans %}
 
                 <dt><label>{% trans "New Status" %}</label></dt>
                 {% if not ticket.can_be_resolved %}<dd>{% trans "This ticket cannot be resolved or closed until the tickets it depends on are resolved." %}</dd>{% endif %}


### PR DESCRIPTION
The My Tickets view generated ticket urls with a '/view' string prefix. This is replaced by proper Django URL resolution.

The public and staff ticket view used a '../../' string prefix which brakes in the public ticket view. They are both replaced with proper Django URL resolution.