### PR TITLE
Sidebar bookmarks, closes  #1175

### DIFF
--- a/helpdesk/settings.py
+++ b/helpdesk/settings.py
@@ -71,6 +71,19 @@ HELPDESK_TICKETS_TIMELINE_ENABLED = getattr(
 HELPDESK_NAVIGATION_ENABLED = getattr(
     settings, 'HELPDESK_NAVIGATION_ENABLED', False)
 
+# Configure a list of Bookmarks/links shown on the bottom of the sidebar
+# menu. Disabled if no bookmark is configured.
+#
+# Set to a list of dictionary in one of the following forms:
+# - { 'URL': external_url, 'label': label } .. external link
+# - { 'name': internal_name, 'label': label } .. internal name is resolved with reverse()
+#
+# If the label is omitted, the URL or name respectively is used instead.
+
+HELPDESK_BOOKMARKS = getattr(
+    settings, 'HELPDESK_BOOKMARKS', [])
+
+
 # use public CDNs to serve jquery and other javascript by default?
 # otherwise, use built-in static copy
 HELPDESK_USE_CDN = getattr(settings, 'HELPDESK_USE_CDN', False)

--- a/helpdesk/templates/helpdesk/navigation-sidebar.html
+++ b/helpdesk/templates/helpdesk/navigation-sidebar.html
@@ -91,5 +91,23 @@
           </a>
         </li>
         {% endif %}
+      {% endif %}
+      {% if helpdesk_settings.HELPDESK_BOOKMARKS and user.is_authenticated %}
+      <li><hr class="dropdown-divider"></li>
+      {% for bookmark in helpdesk_settings.HELPDESK_BOOKMARKS %}
+      <li class="nav-item">
+        {% if bookmark.URL %}
+	<a class="nav-link" href="{{bookmark.URL}}">
+	  <i class="fas fa-fw fa-external-link-alt"></i>
+	  <span>{% trans bookmark.label|default:bookmark.URL %}</span>
+	</a>
+	{% else %}
+	<a class="nav-link" href="{% url bookmark.name %}">
+	  <i class="fas fa-fw fa-arrow-right"></i>
+	  <span>{% trans bookmark.label|default:bookmark.name %}</span>
+	</a>
+	{% endif %}
+      </li>
+      {% endfor %}
     {% endif %}
     </ul>


### PR DESCRIPTION
This PR adds a configuration setting:

     HELPDESK_BOOKMARKS

When set to a list of 'bookmarks', an additional section is shown on the sidebar menu, rendering the bookmarks.

There are two types of bookmarks:

- internal: given as names to resolve by the `reverse()` method of the URL dispatcher
- external: given as URLs.

They are rendered differently so the user can distinguish if she will stay in the Django project or leave to another site.

A bookmark is specified in the following way:
- internal: `{ 'name': `_internal_name_`, 'label': `_label_ }`
- external: `{ 'URL': `_external_url_`, 'label': `_label_ }`

The `label` is the link text. It is optional, if not given the `name` or `URL` is used instead.