### PR TITLE
repair pre-set replies broken due to raw url parameter name mismatch

### DIFF
--- a/helpdesk/urls.py
+++ b/helpdesk/urls.py
@@ -103,7 +103,7 @@ urlpatterns = [
         staff.delete_ticket_checklist,
         name="delete_ticket_checklist"
     ),
-    re_path(r"^raw/(?P<type>\w+)/$", staff.raw_details, name="raw"),
+    re_path(r"^raw/(?P<type_>\w+)/$", staff.raw_details, name="raw"),
     path("rss/", staff.rss_list, name="rss_index"),
     path("reports/", staff.report_index, name="report_index"),
     re_path(r"^reports/(?P<report>\w+)/$",


### PR DESCRIPTION
In https://github.com/django-helpdesk/django-helpdesk/commit/574395ee2814486e6bdca54dad83081279cb20b7#diff-206db4cdb6cf21b5ed528d9c5ebf6be95c221a1da93bbf1d2470521af208774eL1316, the raw_details parameter was changed from `type` to `type_` but the corresponding path regex parameter was not also updated, rendering pre-set replies unloadable.

