### PR TITLE
delete_query view should be catching a "pk" field

### DIFF
--- a/helpdesk/urls.py
+++ b/helpdesk/urls.py
@@ -119,7 +119,7 @@ urlpatterns = [
     re_path(r"^reports/(?P<report>\w+)/$",
             staff.run_report, name="run_report"),
     path("save_query/", staff.save_query, name="savequery"),
-    path("delete_query/<int:id>/", staff.delete_saved_query, name="delete_query"),
+    path("delete_query/<int:pk>/", staff.delete_saved_query, name="delete_query"),
     path("settings/", staff.EditUserSettingsView.as_view(), name="user_settings"),
     path("ignore/", staff.email_ignore, name="email_ignore"),
     path("ignore/add/", staff.email_ignore_add, name="email_ignore_add"),


### PR DESCRIPTION
Simple BUGFIX as staff.delete_saved_query function is expecting a pk field  (and not an id field).