### PR TITLE
Moving python time_spent calculation to database aggregation

### DIFF
--- a/helpdesk/models.py
+++ b/helpdesk/models.py
@@ -362,11 +362,8 @@ class Queue(models.Model):
         """Return back total time spent on the ticket. This is calculated value
         based on total sum from all FollowUps
         """
-        total = datetime.timedelta(0)
-        for val in self.ticket_set.all():
-            if val.time_spent:
-                total = total + val.time_spent
-        return total
+        res = FollowUp.objects.filter(ticket__queue=self).aggregate(models.Sum('time_spent'))
+        return res.get('time_spent__sum', datetime.timedelta(0))
 
     @property
     def time_spent_formated(self):
@@ -582,11 +579,8 @@ class Ticket(models.Model):
         """Return back total time spent on the ticket. This is calculated value
         based on total sum from all FollowUps
         """
-        total = datetime.timedelta(0)
-        for val in self.followup_set.all():
-            if val.time_spent:
-                total = total + val.time_spent
-        return total
+        res = FollowUp.objects.filter(ticket=self).aggregate(models.Sum('time_spent'))
+        return res.get('time_spent__sum', datetime.timedelta(0))
 
     @property
     def time_spent_formated(self):


### PR DESCRIPTION
With an outstanding number of followups, the time_spent count in the Queue model is very slow.

By turning over the count at the database level, the calculation was way faster.

To normalize the behavior, I have also modified the time_spent property for the Ticket model.