### PR TITLE
Fix for titles not updating

### DIFF
--- a/helpdesk/update_ticket.py
+++ b/helpdesk/update_ticket.py
@@ -198,7 +198,6 @@ def update_ticket(
         files=None,
         public=False,
         owner=-1,
-        ticket_title=None,
         priority=-1,
         queue=-1,
         new_status=None,
@@ -268,13 +267,13 @@ def update_ticket(
 
     files = process_attachments(f, files) if files else []
 
-    if ticket_title and ticket_title != ticket.title:
+    if title and title != ticket.title:
         c = f.ticketchange_set.create(
             field=_('Title'),
             old_value=ticket.title,
-            new_value=ticket_title,
+            new_value=title,
         )
-        ticket.title = ticket_title
+        ticket.title = title
 
     if new_status != old_status:
         c = f.ticketchange_set.create(

--- a/helpdesk/update_ticket.py
+++ b/helpdesk/update_ticket.py
@@ -268,9 +268,6 @@ def update_ticket(
 
     files = process_attachments(f, files) if files else []
 
-    if not ticket_title and title:
-        ticket_title = title
-        
     if ticket_title and ticket_title != ticket.title:
         c = f.ticketchange_set.create(
             field=_('Title'),

--- a/helpdesk/update_ticket.py
+++ b/helpdesk/update_ticket.py
@@ -268,6 +268,9 @@ def update_ticket(
 
     files = process_attachments(f, files) if files else []
 
+    if not ticket_title and title:
+        ticket_title = title
+        
     if ticket_title and ticket_title != ticket.title:
         c = f.ticketchange_set.create(
             field=_('Title'),


### PR DESCRIPTION
"fix" for issue #1168. This works but I doubt this is the intended solution.  Let me know how you want to handle ticket_title vs title going forward and I can make the needed changes.

This is the current staff.py call for this (below). However update tickets has options for both `title` and `ticket_title`.
```python
    update_ticket(
        request.user,
        ticket,
        title = title,
        comment = comment,
        files = request.FILES.getlist('attachment'),
        public = request.POST.get('public', False),
        owner = int(request.POST.get('owner', -1)),
        priority = int(request.POST.get('priority', -1)),
        queue = int(request.POST.get('queue', -1)),
        new_status = new_status,
        time_spent = get_time_spent_from_request(request),
        due_date = get_due_date_from_request_or_ticket(request, ticket),
        new_checklists = new_checklists,
        customfields_form = customfields_form,
    )
```

edit: for linking Fixes #1168 