### PR TITLE
BUG - Bug workflow ubuntu latest deprecated 

### DIFF
--- a/.github/workflows/build-standalone-docker-image.yml
+++ b/.github/workflows/build-standalone-docker-image.yml
@@ -7,11 +7,11 @@ on:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu 24
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Log in to Docker Hub
       run: echo '${{ secrets.DOCKER_HUB_PASS }}' | docker login -u djangohelpdesk --password-stdin

--- a/.github/workflows/build-standalone-docker-image.yml
+++ b/.github/workflows/build-standalone-docker-image.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu 24
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
   build:
 
-    runs-on: ubuntu 24
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -5,20 +5,20 @@ on: [pull_request]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu 24
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
         django-version: ["32","4"]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements-testing.txt')}}-${{ hashFiles('tox.ini') }}-${{ matrix.python-version }}-${{ matrix.django-version }}

--- a/.github/workflows/release_to_pypi.yml
+++ b/.github/workflows/release_to_pypi.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build-n-publish:
     name: Build and publish to PyPI
-    runs-on: ubuntu 24
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout source

--- a/.github/workflows/release_to_pypi.yml
+++ b/.github/workflows/release_to_pypi.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build-n-publish:
     name: Build and publish to PyPI
-    runs-on: ubuntu-latest
+    runs-on: ubuntu 24
 
     steps:
       - name: Checkout source


### PR DESCRIPTION
Workflows are failing due to the pending deprecation of workflow v2 https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down

Merging this into the merge requests #1232 and #1234 should fix the respective workflow issues.