### PR TITLE
BUG-1230 standalone postgresql v12-->v13

### DIFF
--- a/docs/standalone.rst
+++ b/docs/standalone.rst
@@ -5,7 +5,7 @@ You can find standalone docker images at `djangohelpdesk/standalone:latest <http
 
 You will also find an alternative `standalone-extras <https://hub.docker.com/r/djangohelpdesk/standalone-extras>`_ image with extra libraries needed to use the standalone image on cloud platforms such as AWS. You can find a full list of extra packages included in the extra's image `here <https://github.com/django-helpdesk/django-helpdesk/blob/main/standalone/requirements-extras.txt>`_.
 
-Installation using docker-compose
+Installation using docker compose
 ------------
 
 1. Clone the django-helpdesk repository:
@@ -21,16 +21,22 @@ Installation using docker-compose
     cd django-helpdesk/standalone
 
 3. Execute the installation script:
-   
-   .. code-block:: bash
-   
-    ./setup.sh
 
+   .. code-block:: bash
+
+      ./setup.sh
+
+   Set the POSTGRES major version if you are deploying to an existing POSTGRES instance other than the default shown within the docker-compose file. For example:
+
+   .. code-block:: bash
+
+      export POSTGRES_MAJOR_VERSION=15
+   
 4. Start the services:
 
    .. code-block:: bash
    
-    docker-compose up
+    docker compose up
 
 
 Creating an Admin User

--- a/standalone/Dockerfile
+++ b/standalone/Dockerfile
@@ -1,3 +1,4 @@
+#see github workflows for docker build command
 FROM python:3.11-slim-bullseye
 LABEL src=https://github.com/django-helpdesk/django-helpdesk
 RUN apt-get update
@@ -6,7 +7,10 @@ RUN apt-get install -yqq \
    postgresql-client \
    cron \
    git
-COPY . /opt/
+ 
+COPY django-helpdesk /opt/django-helpdesk
+RUN pip3 install --upgrade pip
+RUN pip3 install packaging
 RUN pip3 install -r /opt/django-helpdesk/requirements.txt
 RUN pip3 install -r /opt/django-helpdesk/standalone/requirements.txt
 WORKDIR /opt/django-helpdesk

--- a/standalone/docker-compose.yml
+++ b/standalone/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - postgres
 
   postgres:
-    image: postgres:12-bullseye
+    image: postgres:13-bullseye
     volumes:
       - postgres_data:/var/lib/postgresql/data
     env_file: docker.env

--- a/standalone/docker-compose.yml
+++ b/standalone/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '2'
-
 # Define named volumes
 volumes:
   caddy_data:
@@ -30,7 +28,7 @@ services:
       - postgres
 
   postgres:
-    image: postgres:13-bullseye
+    image: postgres:${POSTGRES_MAJOR_VERSION:-17}-bullseye
     volumes:
       - postgres_data:/var/lib/postgresql/data
     env_file: docker.env


### PR DESCRIPTION
Fixes #1230

## Summary
This PR addresses the startup issues with the docker standalone startup.

## Testing Performed
I manually tested the following scenarios:

*  Running the application
*  Creating a superuser account
*  Creating a queue
*  Creating and deleting a ticket

## Known Issue: Migration Handling
One limitation of this fix is that it does not handle database migrations automatically. If the existing PostgreSQL database was initialized with version 12 or older, attempting to open the volume with a PostgreSQL 13 container will result in an error due to version incompatibility.

## Next Steps
A proper migration strategy (e.g., using [pg_upgrade](https://www.postgresql.org/docs/13/pgupgrade.html) or a documented backup/restore process) may be required for upgrades.

Do you need me to make these changes or is this PR fine as it is? 