### PR TITLE
Fix error when email does not create ticket

### DIFF
--- a/helpdesk/email.py
+++ b/helpdesk/email.py
@@ -617,7 +617,9 @@ def create_object_from_email_message(message, ticket_id, payload, files, logger)
             new = True
         else:
             # Possibly an email with no body but has an attachment
-            logger.debug("The QUEUE_EMAIL_BOX_UPDATE_ONLY setting is True so new ticket not created.")
+            logger.debug(
+                "The QUEUE_EMAIL_BOX_UPDATE_ONLY setting is True so new ticket not created."
+            )
             return None
     # Old issue being re-opened
     elif ticket.status == Ticket.CLOSED_STATUS:

--- a/helpdesk/settings.py
+++ b/helpdesk/settings.py
@@ -400,13 +400,6 @@ HELPDESK_KB_ENABLED = (
     else getattr(settings, "HELPDESK_KB_ENABLED", True)
 )
 
-# Include all signatures and forwards in the first ticket message if set
-# Useful if you get forwards dropped from them while they are useful part
-# of request
-HELPDESK_FULL_FIRST_MESSAGE_FROM_EMAIL = getattr(
-    settings, "HELPDESK_FULL_FIRST_MESSAGE_FROM_EMAIL", False
-)
-
 # If set then we always save incoming emails as .eml attachments
 # which is quite noisy but very helpful for complicated markup, forwards and so on
 # (which gets stripped/corrupted otherwise)

--- a/helpdesk/tests/test_get_email.py
+++ b/helpdesk/tests/test_get_email.py
@@ -501,7 +501,7 @@ class GetEmailCommonTests(TestCase):
         ticket = helpdesk.email.extract_email_metadata(
             message.as_string(), self.queue_public, self.logger
         )
-        self.assertTrue(ticket is not None, "Ticket not created when it should be.")
+        self.assertIsNotNone(ticket, "Ticket not created when it should be.")
 
     @override_settings(QUEUE_EMAIL_BOX_UPDATE_ONLY=True)
     def test_email_for_no_new_ticket_when_setting_only_allows_update(self):
@@ -512,8 +512,7 @@ class GetEmailCommonTests(TestCase):
         ticket = helpdesk.email.extract_email_metadata(
             message.as_string(), self.queue_public, self.logger
         )
-        self.assertTrue(
-            ticket is None, f"Ticket was created when it should not be: {ticket}"
+        self.assertIsNone(ticket, f"Ticket was created when it should not be: {ticket}"
         )
 
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages, setup
 import sys
 
 
-version = '1.3.1'
+version = '1.4.0'
 
 
 # Provided as an attribute, so you can append to these instead


### PR DESCRIPTION
Fixes #1247 

- Added a return with None when QUEUE_EMAIL_BOX_UPDATE_ONLY=True to prevent further processing resulting in an exception
- Changed import of helpdesk.settings to use alias of helpdesk_settings inline with usage in all other modules using the helpdesk settings module.
- Removed HELPDESK_FULL_FIRST_MESSAGE_FROM_EMAIL from helpdesk.settings.py to avoid confusion since it is only accessed as a Django setting and unit tests would fail if used from helpdesk.settings since the mocking overrides would fail.