### PR TITLE
Fix error when email has attachment mime part and content mime part missing or empty 

### DIFF
--- a/helpdesk/tests/test_get_email.py
+++ b/helpdesk/tests/test_get_email.py
@@ -535,7 +535,7 @@ class GetEmailCommonTests(TestCase):
 
     def test_with_attachment_but_empty_body(self):
         """
-        Test an email that has no body content but does have an attachment
+        Test an email that has an empty body but does have an attachment
         """
         message, _, _ = utils.generate_multipart_email(
             type_list=["plain", "image"],

--- a/helpdesk/tests/test_get_email.py
+++ b/helpdesk/tests/test_get_email.py
@@ -514,6 +514,45 @@ class GetEmailCommonTests(TestCase):
         )
         self.assertIsNone(ticket, f"Ticket was created when it should not be: {ticket}")
 
+    def test_with_attachment_but_no_body_part(self):
+        """
+        Test an email that has no body content but does have an attachment
+        """
+        message, _, _ = utils.generate_multipart_email(
+            type_list=["image"],
+        )
+        # Now send the part to the email workflow
+        extract_email_metadata(message.as_string(), self.queue_public, self.logger)
+        self.assertEqual(len(mail.outbox), 1)  # @UndefinedVariable
+        ticket = Ticket.objects.get()
+        followup = ticket.followup_set.get()
+        # Check  attachment is stored as attached file
+        email_attachment_found = followup.followupattachment_set.exists()
+        self.assertTrue(
+            email_attachment_found,
+            "Email attachment file not found in ticket attachment for empty body.",
+        )
+
+    def test_with_attachment_but_empty_body(self):
+        """
+        Test an email that has no body content but does have an attachment
+        """
+        message, _, _ = utils.generate_multipart_email(
+            type_list=["plain", "image"],
+            body="",
+        )
+        # Now send the part to the email workflow
+        extract_email_metadata(message.as_string(), self.queue_public, self.logger)
+        self.assertEqual(len(mail.outbox), 1)  # @UndefinedVariable
+        ticket = Ticket.objects.get()
+        followup = ticket.followup_set.get()
+        # Check  attachment is stored as attached file
+        email_attachment_found = followup.followupattachment_set.exists()
+        self.assertTrue(
+            email_attachment_found,
+            "Email attachment file not found in ticket attachment for empty body.",
+        )
+
 
 class EmailTaskTests(TestCase):
     def setUp(self):

--- a/helpdesk/tests/utils.py
+++ b/helpdesk/tests/utils.py
@@ -288,15 +288,18 @@ def add_simple_email_headers(
 def generate_mime_part(
     locale: str = "en_US",
     part_type: str = "plain",
+    body: str = None,
 ) -> typing.Optional[Message]:
     """
-    Generates amime part of the sepecified type
+    Generates a mime part of the specified type
 
     :param locale: change this to generate locale specific strings
     :param text_type: options are plain, html, image (attachment), file (attachment)
+    :param body: if provided then will be added to the plain mime part only
     """
     if "plain" == part_type:
-        body = get_fake("text", locale=locale, min_length=1024)
+        if body is None:
+            body = get_fake("text", locale=locale, min_length=1024)
         msg = MIMEText(body, part_type)
     elif "html" == part_type:
         body = get_fake_html(locale=locale, wrap_in_body_tag=True)
@@ -317,6 +320,7 @@ def generate_multipart_email(
     type_list: typing.List[str] = ["plain", "html", "image"],
     sub_type: str = None,
     use_short_email: bool = False,
+    body: str = None,
 ) -> typing.Tuple[Message, typing.Tuple[str, str], typing.Tuple[str, str]]:
     """
     Generates an email including headers with the defined multiparts
@@ -325,10 +329,11 @@ def generate_multipart_email(
     :param type_list: options are plain, html, image (attachment), file (attachment), and executable (.exe attachment)
     :param sub_type: multipart sub type that defaults to "mixed" if not specified
     :param use_short_email: produces a "To" or "From" that is only the email address if True
+    :param body: if provided then will be added to the plain mime part only
     """
     msg = MIMEMultipart(sub_type) if sub_type else MIMEMultipart()
     for part_type in type_list:
-        msg.attach(generate_mime_part(locale=locale, part_type=part_type))
+        msg.attach(generate_mime_part(locale=locale, part_type=part_type, body=body))
     from_meta, to_meta = add_simple_email_headers(
         msg, locale=locale, use_short_email=use_short_email
     )
@@ -336,12 +341,13 @@ def generate_multipart_email(
 
 
 def generate_text_email(
-    locale: str = "en_US", use_short_email: bool = False
+    locale: str = "en_US", use_short_email: bool = False, body: str = None,
 ) -> typing.Tuple[Message, typing.Tuple[str, str], typing.Tuple[str, str]]:
     """
     Generates an email including headers
     """
-    body = get_fake("text", locale=locale, min_length=1024)
+    if body is None:
+        body = get_fake("text", locale=locale, min_length=1024)
     msg = MIMEText(body)
     from_meta, to_meta = add_simple_email_headers(
         msg, locale=locale, use_short_email=use_short_email

--- a/helpdesk/tests/utils.py
+++ b/helpdesk/tests/utils.py
@@ -341,7 +341,9 @@ def generate_multipart_email(
 
 
 def generate_text_email(
-    locale: str = "en_US", use_short_email: bool = False, body: str = None,
+    locale: str = "en_US",
+    use_short_email: bool = False,
+    body: str = None,
 ) -> typing.Tuple[Message, typing.Tuple[str, str], typing.Tuple[str, str]]:
     """
     Generates an email including headers


### PR DESCRIPTION
This fixes #1240 

Codes changes include:

1. Enhance utility methods in the tests folder to allow passing in an optional body part to sim0lify creating a test for the bug fix.
2. Code for situations where the email only contains an attachment mime part or contains an attachment and and empty content body part.
3. Added unit tests for the 2 scenarios defined in 2 above.