### PR TITLE
Fix datatable default sort

### DIFF
--- a/helpdesk/templates/helpdesk/ticket_list.html
+++ b/helpdesk/templates/helpdesk/ticket_list.html
@@ -449,7 +449,8 @@
                     {% if helpdesk_settings.HELPDESK_KB_ENABLED %}
                     {data: "kbitem"},
                     {% endif %}
-                ]
+                ],
+                order: []
             });
 
             {# Timeline initialization when tab is displayed #}


### PR DESCRIPTION
When the user clicks the "Apply Filters" button having selected a sorting column and sort order, the dataTable will render in the selected order. The ordering enacted by clicking on one of the column titles will then apply that columns ordering until the user clicks the "Apply Filters" button again at which point it will relaod the data using the selected ordering from the "Sorting" dropdown.