### PR TITLE
Allow "My Tickets" visibility for staff users to be controlled by a setting

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,6 +1,9 @@
 API
 ===
 
+.. contents:: In this document...
+   :depth: 2
+
 A REST API (built with ``djangorestframework``) is available in order to list, create, update and delete tickets from
 other tools thanks to HTTP requests.
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -1,9 +1,12 @@
 Installation/integration into an existing Django application
-============
+============================================================
 
 .. note:: 
 
     For standalone installation, refer to the :doc:`standalone installation docs <standalone>`.
+
+.. contents:: In this document...
+   :depth: 2
 
 ``django-helpdesk`` installation isn't difficult, but it requires you have a bit 
 of existing know-how about Django.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -1,6 +1,9 @@
 Settings
 ========
 
+.. contents:: In this document...
+   :depth: 2
+
 First, django-helpdesk needs  ``django.core.context_processors.request`` activated, so you must add it to the ``settings.py``. Add the following::
 
     TEMPLATES = [
@@ -86,6 +89,10 @@ These changes are visible throughout django-helpdesk
 - **HELPDESK_NAVIGATION_ENABLED** Show extended navigation by default, to all users, irrespective of staff status?
 
   **Default:** ``HELPDESK_NAVIGATION_ENABLED = False``
+  
+- **HELPDESK_SHOW_MY_TICKETS_IN_NAV_FOR_STAFF** Show "My tickets" for staff. Typically used for help desk deploymnets that allow staff to create tickets to action other staff members.
+
+  **Default:** ``HELPDESK_SHOW_MY_TICKETS_IN_NAV_FOR_STAFF = True``
 
 - **HELPDESK_TRANSLATE_TICKET_COMMENTS** Show dropdown list of languages that ticket comments can be translated into via Google Translate?
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -90,7 +90,7 @@ These changes are visible throughout django-helpdesk
 
   **Default:** ``HELPDESK_NAVIGATION_ENABLED = False``
   
-- **HELPDESK_SHOW_MY_TICKETS_IN_NAV_FOR_STAFF** Show "My tickets" for staff. Typically used for help desk deploymnets that allow staff to create tickets to action other staff members.
+- **HELPDESK_SHOW_MY_TICKETS_IN_NAV_FOR_STAFF** Show "My tickets" for staff. Typically used for help desk deployments that allow staff to create tickets to action other staff members.
 
   **Default:** ``HELPDESK_SHOW_MY_TICKETS_IN_NAV_FOR_STAFF = True``
 

--- a/helpdesk/settings.py
+++ b/helpdesk/settings.py
@@ -91,6 +91,12 @@ HELPDESK_TICKETS_TIMELINE_ENABLED = getattr(
 # status?
 HELPDESK_NAVIGATION_ENABLED = getattr(settings, "HELPDESK_NAVIGATION_ENABLED", False)
 
+# Show the "My Tickets" navigation option for staff members - typically this is for when
+# staff can create tickets to action other staff.
+HELPDESK_SHOW_MY_TICKETS_IN_NAV_FOR_STAFF = getattr(
+    settings, "HELPDESK_SHOW_MY_TICKETS_IN_NAV_FOR_STAFF", True
+)
+
 # use public CDNs to serve jquery and other javascript by default?
 # otherwise, use built-in static copy
 HELPDESK_USE_CDN = getattr(settings, "HELPDESK_USE_CDN", False)

--- a/helpdesk/templates/helpdesk/navigation-sidebar.html
+++ b/helpdesk/templates/helpdesk/navigation-sidebar.html
@@ -40,12 +40,14 @@
             <span>{% trans "New Ticket" %}</span>
           </a>
         </li>
+        {% if helpdesk_settings.HELPDESK_SHOW_MY_TICKETS_IN_NAV_FOR_STAFF %}
         <li class="nav-item{% if 'my-tickets' in request.path %} active{% endif %}">
             <a class="nav-link" href="{% url 'helpdesk:my-tickets' %}">
                 <i class="fas fa-fw fa-tasks"></i>
                 <span>{% trans "My Tickets" %}</span>
             </a>
         </li>
+        {% endif %}
         <li class="nav-item{% if 'reports' in request.path %} active{% endif %}">
           <a class="nav-link" href="{% url 'helpdesk:report_index' %}">
             <i class="fas fa-fw fa-chart-area"></i>


### PR DESCRIPTION
Depending on the usage of the helpdesk system, some organisations may not want to show "My Tickets" for staff users if the staff do not create tickets themselves.
To support deployments that do not allow staff to create tickets, the "MyTickets" navigation option can be removed for all staff users by a setting.