### PR TITLE
feat: add saved queries list view page with run and delete support

### DIFF
--- a/helpdesk/templates/helpdesk/navigation-sidebar.html
+++ b/helpdesk/templates/helpdesk/navigation-sidebar.html
@@ -34,6 +34,12 @@
             {% endif %}
           </div>
         </li>
+        <li class="nav-item{% if 'saved-searches' in request.path %} active{% endif %}">
+          <a class="nav-link" href="{% url 'helpdesk:saved_searches_list' %}">
+            <i class="fas fa-fw fa-save"></i>
+            <span>{% trans "Manage Saved Queries" %}</span>
+          </a>
+        </li>
         <li class="nav-item{% if 'submit' in request.path %} active{% endif %}">
           <a class="nav-link" href="{% url 'helpdesk:submit' %}">
             <i class="fas fa-fw fa-plus-circle"></i>

--- a/helpdesk/templates/helpdesk/saved_searches_list.html
+++ b/helpdesk/templates/helpdesk/saved_searches_list.html
@@ -1,0 +1,59 @@
+{% extends "helpdesk/base.html" %}
+{% load i18n %}
+
+{% block helpdesk_title %}
+  {% trans "Saved Queries" %}
+{% endblock %}
+
+{% block helpdesk_breadcrumb %}
+  <li class="breadcrumb-item">
+    <a href="{% url 'helpdesk:list' %}">{% trans "Tickets" %}</a>
+  </li>
+  <li class="breadcrumb-item active">{% trans "Saved Queries" %}</li>
+{% endblock %}
+
+{% block helpdesk_body %}
+  <div class="container mt-4">
+    <h3 class="mb-4">{% trans "Saved Queries" %}</h3>
+
+    {% if saved_queries %}
+      <ul class="list-group">
+        {% for q in saved_queries %}
+          <li class="list-group-item d-flex justify-content-between align-items-center">
+            <div>
+              <a href="{% url 'helpdesk:list' %}?saved_query={{ q.id }}" class="text-decoration-none">
+                {{ q.title }}
+                {% if q.shared %}
+                  <small class="text-muted ms-2 fst-italic">
+                    {% if q.user == user %}
+                      ({% trans "Shared" %})
+                    {% else %}
+                      ({% trans "Shared by" %} {{ q.user.get_username }})
+                    {% endif %}
+                  </small>
+                {% endif %}
+              </a>
+            </div>
+            <div class="d-flex">
+              <a href="{% url 'helpdesk:list' %}?saved_query={{ q.id }}"
+                 class="btn btn-sm btn-outline-primary mr-2"
+                 title="{% trans 'Run this query' %}">
+                <i class="fas fa-play"></i> {% trans "Run" %}
+              </a>
+
+              {% if q.user == user %}
+                <a href="{% url 'helpdesk:delete_query' q.id %}"
+                   class="btn btn-sm btn-outline-danger"
+                   title="{% trans 'Delete this query' %}">
+                  <i class="fas fa-trash"></i>
+                </a>
+              {% endif %}
+            </div>
+          </li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <p>{% trans "No saved queries found." %}</p>
+    {% endif %}
+  </div>
+{% endblock %}

--- a/helpdesk/urls.py
+++ b/helpdesk/urls.py
@@ -119,6 +119,7 @@ urlpatterns = [
     path("rss/", staff.rss_list, name="rss_index"),
     path("reports/", staff.report_index, name="report_index"),
     re_path(r"^reports/(?P<report>\w+)/$", staff.run_report, name="run_report"),
+    path("saved-searches/", staff.saved_searches_list, name="saved_searches_list"),
     path("save_query/", staff.save_query, name="savequery"),
     path("delete_query/<int:pk>/", staff.delete_saved_query, name="delete_query"),
     path("settings/", staff.EditUserSettingsView.as_view(), name="user_settings"),

--- a/helpdesk/views/staff.py
+++ b/helpdesk/views/staff.py
@@ -1688,6 +1688,23 @@ run_report = staff_member_required(run_report)
 
 
 @helpdesk_staff_member_required
+def saved_searches_list(request):
+    user = request.user
+    saved_queries = SavedSearch.objects.filter(Q(user=user) | Q(shared=True)).distinct()
+
+    return render(
+        request,
+        "helpdesk/saved_searches_list.html",
+        {
+            "saved_queries": saved_queries,
+        },
+    )
+
+
+saved_searches_list = staff_member_required(saved_searches_list)
+
+
+@helpdesk_staff_member_required
 def save_query(request):
     title = request.POST.get("title", None)
     shared = request.POST.get("shared", False)


### PR DESCRIPTION
This feature adds a new Manage Saved Queries page accessible at `helpdesk/saved-searches/`. The page provides users with a list view of their saved queries, enabling easy management of these queries.

**Features**
- Displays all saved queries created by the user or shared with them.
- Allows users to run any saved query directly from the list.
- Enables users to delete saved queries they no longer need.
- Intuitive UI for managing saved queries efficiently.