### PR TITLE
Add priority filter to ticket list view and template

### DIFF
--- a/helpdesk/templates/helpdesk/filters/priority.html
+++ b/helpdesk/templates/helpdesk/filters/priority.html
@@ -1,0 +1,15 @@
+{% load i18n humanize %}
+{% load static %}
+{% load in_list %}
+<div class="form-row">
+  <div class="col col-sm-3">
+    <label for='id_priority'>{% trans "Priority" %}:</label>
+  </div>
+  <div class="col col-sm-3">
+    <select id='id_priority' name='priority' multiple='selected' size='5'>{% for p in priority_choices %}<option value='{{ p.0 }}'{% if p.0|in_list:query_params.filtering.priority__in %} selected='selected'{% endif %}>{{ p.1 }}</option>{% endfor %}</select>
+  </div>
+  <div class="col col-sm-6">
+    <button class="filterBuilderRemove btn btn-danger btn-sm float-right"><i class="fas fa-trash-alt"></i></button>
+  </div>
+  <div class='form-row filterHelp'>{% trans "Ctrl-click to select multiple options" %}</div>
+</div>

--- a/helpdesk/templates/helpdesk/ticket_list.html
+++ b/helpdesk/templates/helpdesk/ticket_list.html
@@ -171,6 +171,9 @@
                                         <option id="filterBuilderSelect-Sort" value="Sort"{% if query_params.sorting %} disabled{% endif %}>
                                             {% trans "Sorting" %}
                                         </option>
+                                        <option id="filterBuilderSelect-Priority" value="Priority"{% if query_params.filtering.priority__in %} disabled{% endif %}>
+                                            {% trans "Priority" %}
+                                        </option>
                                         <option id="filterBuilderSelect-Owner" value="Owner"{% if query_params.filtering.assigned_to__id__in or query_params.filtering_null.assigned_to__id__isnull %} disabled{% endif %}>
                                             {% trans "Owner" %}
                                         </option>
@@ -200,6 +203,10 @@
                                     class="filterBox{% if query_params.sorting %} filterBoxShow{% endif %} list-group-item"
                                     id="filterBoxSort">
                                     {% include 'helpdesk/filters/sorting.html' %}
+                                </li>
+                                <li class="list-group-item filterBox{% if query_params.filtering.priority__in %} filterBoxShow{% endif %}"
+                                    id="filterBoxPriority">
+                                    {% include 'helpdesk/filters/priority.html' %}
                                 </li>
                                 <li class="filterBox{% if query_params.filtering.assigned_to__id__in or query_params.filtering_null.assigned_to__id__isnull %} filterBoxShow{% endif %} list-group-item"
                                     id=filterBoxOwner>

--- a/helpdesk/views/staff.py
+++ b/helpdesk/views/staff.py
@@ -1077,6 +1077,7 @@ def ticket_list(request):
         "queue",
         "assigned_to",
         "status",
+        "priority",
         "q",
         "sort",
         "sortreverse",
@@ -1089,6 +1090,7 @@ def ticket_list(request):
             ("queue", "queue__id__in"),
             ("assigned_to", "assigned_to__id__in"),
             ("status", "status__in"),
+            ("priority", "priority__in"),
             ("kbitem", "kbitem__in"),
         ]
         filter_null_params = dict(
@@ -1096,6 +1098,7 @@ def ticket_list(request):
                 ("queue", "queue__id__isnull"),
                 ("assigned_to", "assigned_to__id__isnull"),
                 ("status", "status__isnull"),
+                ("priority", "priority__isnull"),
                 ("kbitem", "kbitem__isnull"),
             ]
         )
@@ -1187,6 +1190,7 @@ def ticket_list(request):
             kb_items=kbitem,
             queue_choices=huser.get_queues(),
             status_choices=Ticket.STATUS_CHOICES,
+            priority_choices=Ticket.PRIORITY_CHOICES,
             kbitem_choices=kbitem_choices,
             urlsafe_query=urlsafe_query,
             user_saved_queries=user_saved_queries,


### PR DESCRIPTION
This feature adds a new priority filter to the ticket list view, enhancing ticket management capabilities for helpdesk staff. The filter is integrated into both the frontend template and backend view logic to support efficient sorting based on ticket urgency.

**Features**

- Adds a priority filter dropdown in the ticket list UI.
- Allows staff to filter tickets by predefined priority levels.
- Updates backend logic to handle filtering via query parameters.
- Maintains consistency with existing filter design for a seamless experience.

