### PR TITLE
Add follow-up creation and change tracking on ticket hold status

### DIFF
--- a/helpdesk/views/staff.py
+++ b/helpdesk/views/staff.py
@@ -71,6 +71,7 @@ from helpdesk.models import (
     SavedSearch,
     Ticket,
     TicketCC,
+    TicketChange,
     TicketCustomFieldValue,
     TicketDependency,
     UserSettings,
@@ -89,6 +90,7 @@ import re
 from rest_framework import status
 from rest_framework.decorators import api_view
 import typing
+from django.utils.timezone import now
 
 
 if helpdesk_settings.HELPDESK_KB_ENABLED:
@@ -1380,20 +1382,27 @@ def hold_ticket(request, ticket_id, unhold=False):
 
     if unhold:
         ticket.on_hold = False
-        title = _("Ticket taken off hold")
+        followup_title = _("Ticket taken off hold")
     else:
         ticket.on_hold = True
-        title = _("Ticket placed on hold")
-
-    f = update_ticket(
-        user=request.user,
-        ticket=ticket,
-        title=title,
-        public=True,
-    )
-    f.save()
+        followup_title = _("Ticket placed on hold")
 
     ticket.save()
+
+    followup = FollowUp.objects.create(
+        ticket=ticket,
+        title=followup_title,
+        date=now(),
+        public=True,
+        user=request.user,
+    )
+
+    TicketChange.objects.create(
+        followup=followup,
+        field=_("On Hold"),
+        old_value=str(not ticket.on_hold),
+        new_value=str(ticket.on_hold),
+    )
 
     return HttpResponseRedirect(ticket.get_absolute_url())
 


### PR DESCRIPTION
This feature enhances the ticket hold functionality by automatically creating follow-ups when a ticket is placed on or taken off hold. It also introduces change tracking for the ticket’s on_hold status through the TicketChange log. Additionally, it removes the functionality that updates the ticket title on hold, ensuring the title remains unchanged.

**Features**

- Creates follow-ups with updated titles reflecting hold or unhold actions.
- Logs changes to the ticket’s on_hold status for audit and tracking.
- Removes automatic ticket title updates when a ticket is put on hold.
- Improves visibility into ticket status changes and follow-up history.

