### PR TITLE
Fix ticket ID matching across multiple queues

### DIFF
--- a/helpdesk/email.py
+++ b/helpdesk/email.py
@@ -1090,9 +1090,31 @@ def extract_email_metadata(
                 else DeleteIgnoredTicketException()
             )
 
+    # First try to get ticket ID from the current queue's slug
     ticket_id: typing.Optional[int] = get_ticket_id_from_subject_slug(
         queue.slug, subject, logger
     )
+
+    # If no ticket ID found in the current queue, check all other queues
+    if ticket_id is None:
+        # Get all enabled queues except the current one
+        other_queues = Queue.objects.exclude(id=queue.id).filter(
+            email_box_type__isnull=False, allow_email_submission=True
+        )
+        
+        for other_queue in other_queues:
+            ticket_id = get_ticket_id_from_subject_slug(
+                other_queue.slug, subject, logger
+            )
+            if ticket_id is not None:
+                # Found a matching ticket in another queue, use that queue instead
+                logger.info(
+                    f"Found ticket {ticket_id} matching subject in queue {other_queue.slug} "
+                    f"instead of current queue {queue.slug}"
+                )
+                queue = other_queue
+                break
+
     files = []
     # first message in thread, we save full body to avoid losing forwards and things like that
     include_chained_msgs = (


### PR DESCRIPTION
The issue was that the indentation was incorrect in your code. The block for checking other queues wasn't properly indented under the if ticket_id is None: condition, causing it to be outside the conditional block. This meant the code wasn't executing as intended when processing emails.

With this fix, the code will now properly check other queues only when no ticket ID is found in the current queue, ensuring that emails are correctly associated with existing tickets in any queue before attempting to create new tickets

![Screenshot from 2025-06-17 10-20-29](https://github.com/user-attachments/assets/8dffee9e-cad0-4f75-8ac1-dc20062d752c)
