### PR TITLE
Fix due_date being overwritten by ticket update shortcuts

### DIFF
--- a/helpdesk/update_ticket.py
+++ b/helpdesk/update_ticket.py
@@ -309,7 +309,7 @@ def update_ticket(
         )
         ticket.queue_id = queue
 
-    if due_date != ticket.due_date:
+    if due_date and due_date != ticket.due_date:
         f.ticketchange_set.create(
             field=_("Due on"),
             old_value=ticket.due_date,


### PR DESCRIPTION
resolves #1281

This implementation is safe because [updating the ticket from the form](https://github.com/django-helpdesk/django-helpdesk/blob/main/helpdesk/views/staff.py#L671) already cleans the due_date from the form. When due_date is None, it will be set to the existing ticket.due_date anyways.