### PR TITLE
Fix ticket form update when there are custom required fields

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,8 @@ readme:
 	$(TOX) -e readme
 
 
+PY ?= from django.contrib.auth import get_user_model;print(1 if get_user_model().objects.filter(username="admin").exists() else 0)
+NO_USER ?= $(shell demodesk shell -c '${PY}' --no-imports)
 #: demo - Setup demo project using Python3.
 .PHONY: demo
 demo:
@@ -98,10 +100,12 @@ demo:
 	$(PIP) install -e . --user || $(PIP) install -e .
 	$(PIP) install -e demo --user || $(PIP) install -e demo
 	demodesk migrate --noinput
-	# Create superuser; user will be prompted to manually set a password
+	# Create superuser "admin" if it is not already created.
+	# Script will prompt user to manually set a password.
 	# When you get a prompt, enter a password of your choosing.
 	# We suggest a default of 'Test1234' for the demo project.
-	demodesk createsuperuser --username admin --email helpdesk@example.com
+	
+	@if [ $(NO_USER) -eq 0 ]; then demodesk createsuperuser --username admin --email helpdesk@example.com; fi
 	# Install fixtures
 	demodesk loaddata emailtemplate.json
 	demodesk loaddata demo.json

--- a/helpdesk/templates/helpdesk/ticket.html
+++ b/helpdesk/templates/helpdesk/ticket.html
@@ -233,7 +233,7 @@
 
         </fieldset>
 
-        <button class="btn btn-primary float-right" type='submit'>{% trans "Update This Ticket" %}</button>
+        <button class="btn btn-primary float-right" type='submit' onclick='$("#ShowFurtherEditOptions").click()'>{% trans "Update This Ticket" %}</button>
 
         {% csrf_token %}</form>
 


### PR DESCRIPTION
The ticket form hides some extended fields by default including all the custom fields.
If a custom field that is set as required is rendered then the field is not visible to the user by default and updating the tickets fields that are visible by default fails because there is a javascript error complaining about the lack of visibility of the required field it is trying to add an error message to which is not shown in the UI and the UI is unaware that there is anything wrong.

This fix forces the hidden fields to be displayed before the form validation runs so that the error is visible to the user.

The PR also adds a unit test that specifically deals with required fields but does not test the soultion since there are no UI tests in this app.

Additionally a minor enhancemnet is added to the make script to allow the rundemo script in the makefile to be run repeatedly without issues surroundiung the admin user.