### PR TITLE
Add submitter to roles being emailed on ticket update

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -118,6 +118,10 @@ These changes are visible throughout django-helpdesk
 
   **Default:** ``HELPDESK_EMAIL_SUBJECT_TEMPLATE = "{{ ticket.ticket }} {{ ticket.title|safe }} %(subject)s"``
 
+- **HELPDESK_SEND_EMAIL_NOTIFICATION_FOR_INTERNAL_TICKET_UPDATES** Send email to submitter for internal ticket updates. System only sends to submitter for public ticket updates.
+
+  **Default:** ``HELPDESK_SEND_EMAIL_NOTIFICATION_FOR_INTERNAL_TICKET_UPDATES = False``
+
 - **HELPDESK_EMAIL_FALLBACK_LOCALE** Fallback locale for templated emails when queue locale not found
 
   **Default:** ``HELPDESK_EMAIL_FALLBACK_LOCALE = "en"``

--- a/helpdesk/settings.py
+++ b/helpdesk/settings.py
@@ -350,6 +350,12 @@ HELPDESK_MAX_EMAIL_ATTACHMENT_SIZE = getattr(
     settings, "HELPDESK_MAX_EMAIL_ATTACHMENT_SIZE", 512000
 )
 
+# Send email notifications for internal ticket submitter.
+HELPDESK_SEND_EMAIL_NOTIFICATION_FOR_INTERNAL_TICKET_UPDATES = getattr(
+    settings,
+    "HELPDESK_SEND_EMAIL_NOTIFICATION_FOR_INTERNAL_TICKET_UPDATES",
+    False,
+)
 
 ########################################
 # options for staff.create_ticket view #


### PR DESCRIPTION
Rationalize the email notifications handling into a single method call.
Add ability to enable sending email notifications to submitter via setting for non-public tickets.