### PR TITLE
Fix unassign action in update ticket + refactor the get_active_users

### DIFF
--- a/helpdesk/forms.py
+++ b/helpdesk/forms.py
@@ -19,7 +19,7 @@ from helpdesk.lib import (
     convert_value,
     process_attachments,
     safe_template_context,
-    get_active_users,
+    get_assignable_users,
 )
 from helpdesk.models import (
     Checklist,
@@ -478,7 +478,10 @@ class TicketForm(AbstractTicketForm):
             self.fields["queue"].choices = queue_choices
         self.fields["body"].required = body_reqd
         self.fields["assigned_to"].choices = [("", "--------")] + [
-            (u.id, u.get_username()) for u in get_active_users()
+            (u.id, u.get_username())
+            for u in get_assignable_users(
+                helpdesk_settings.HELPDESK_STAFF_ONLY_TICKET_OWNERS
+            )
         ]
         self._add_form_custom_fields()
 
@@ -635,13 +638,9 @@ class TicketCCForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super(TicketCCForm, self).__init__(*args, **kwargs)
-        if helpdesk_settings.HELPDESK_STAFF_ONLY_TICKET_CC:
-            users = User.objects.filter(is_active=True, is_staff=True).order_by(
-                User.USERNAME_FIELD
-            )
-        else:
-            users = User.objects.filter(is_active=True).order_by(User.USERNAME_FIELD)
-        self.fields["user"].queryset = users
+        self.fields["user"].queryset = get_assignable_users(
+            helpdesk_settings.HELPDESK_STAFF_ONLY_TICKET_CC
+        )
 
 
 class TicketCCUserForm(forms.ModelForm):
@@ -649,13 +648,9 @@ class TicketCCUserForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super(TicketCCUserForm, self).__init__(*args, **kwargs)
-        if helpdesk_settings.HELPDESK_STAFF_ONLY_TICKET_CC:
-            users = User.objects.filter(is_active=True, is_staff=True).order_by(
-                User.USERNAME_FIELD
-            )
-        else:
-            users = User.objects.filter(is_active=True).order_by(User.USERNAME_FIELD)
-        self.fields["user"].queryset = users
+        self.fields["user"].queryset = get_assignable_users(
+            helpdesk_settings.HELPDESK_STAFF_ONLY_TICKET_CC
+        )
 
     class Meta:
         model = TicketCC

--- a/helpdesk/forms.py
+++ b/helpdesk/forms.py
@@ -15,7 +15,12 @@ from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from helpdesk import settings as helpdesk_settings
-from helpdesk.lib import convert_value, process_attachments, safe_template_context
+from helpdesk.lib import (
+    convert_value,
+    process_attachments,
+    safe_template_context,
+    get_active_users,
+)
 from helpdesk.models import (
     Checklist,
     ChecklistTemplate,
@@ -472,16 +477,8 @@ class TicketForm(AbstractTicketForm):
         if queue_choices:
             self.fields["queue"].choices = queue_choices
         self.fields["body"].required = body_reqd
-        if helpdesk_settings.HELPDESK_STAFF_ONLY_TICKET_OWNERS:
-            assignable_users = User.objects.filter(
-                is_active=True, is_staff=True
-            ).order_by(User.USERNAME_FIELD)
-        else:
-            assignable_users = User.objects.filter(is_active=True).order_by(
-                User.USERNAME_FIELD
-            )
         self.fields["assigned_to"].choices = [("", "--------")] + [
-            (u.id, u.get_username()) for u in assignable_users
+            (u.id, u.get_username()) for u in get_active_users()
         ]
         self._add_form_custom_fields()
 

--- a/helpdesk/lib.py
+++ b/helpdesk/lib.py
@@ -284,10 +284,10 @@ def daily_time_spent_calculation(earliest, latest, open_hours):
     return time_spent_seconds
 
 
-def get_active_users() -> QuerySet:
-    users = User.objects.filter(is_active=True).order_by(User.USERNAME_FIELD)
+def get_assignable_users(filter_staff: bool) -> QuerySet:
+    users = User.objects.filter(is_active=True)
 
-    if helpdesk_settings.HELPDESK_STAFF_ONLY_TICKET_OWNERS:
+    if filter_staff:
         users = users.filter(is_staff=True)
 
-    return users
+    return users.order_by(User.USERNAME_FIELD)

--- a/helpdesk/templates/helpdesk/filters/owner.html
+++ b/helpdesk/templates/helpdesk/filters/owner.html
@@ -12,7 +12,7 @@
                 {% trans "Unassigned" %}
             </option>
             {% endwith %}
-            {% for u in user_choices %}
+            {% for u in assignable_users %}
             <option value='{{ u.id }}'{% if u.id|in_list:query_params.filtering.assigned_to__id__in %} selected='selected'{% endif %}>
                 {{ u.get_username }}
             </option>

--- a/helpdesk/templates/helpdesk/ticket.html
+++ b/helpdesk/templates/helpdesk/ticket.html
@@ -161,7 +161,7 @@
                 <dt><label for='id_owner'>{% trans "Owner" %}</label></dt>
                 <dd>
                     <select id='id_owner' name='owner'>
-                        <option value='0'>{% trans "Unassign" %}</option>
+                        <option value='0'>{% trans "Unassigned" %}</option>
                         {% for u in assignable_users %}
                             <option value='{{ u.id }}'{% if u.id == ticket.assigned_to.id %} selected{% endif %}>{{ u }}</option>
                         {% endfor %}

--- a/helpdesk/templates/helpdesk/ticket.html
+++ b/helpdesk/templates/helpdesk/ticket.html
@@ -159,7 +159,14 @@
                 <dd><input type='text' name='title' value='{{ ticket.title|escape }}' /></dd>
 
                 <dt><label for='id_owner'>{% trans "Owner" %}</label></dt>
-                <dd><select id='id_owner' name='owner'><option value='0'>{% trans "Unassign" %}</option>{% for u in active_users %}{% if u.id == ticket.assigned_to.id %}<option value='{{ u.id }}' selected>{{ u }}</option>{% else %}<option value='{{ u.id }}'>{{ u }}</option>{% endif %}{% endfor %}</select></dd>
+                <dd>
+                    <select id='id_owner' name='owner'>
+                        <option value='0'>{% trans "Unassign" %}</option>
+                        {% for u in assignable_users %}
+                            <option value='{{ u.id }}'{% if u.id == ticket.assigned_to.id %} selected{% endif %}>{{ u }}</option>
+                        {% endfor %}
+                    </select>
+                </dd>
 
                 <dt><label for='id_priority'>{% trans "Priority" %}</label></dt>
                 <dd><select id='id_priority' name='priority'>{% for p in priorities %}{% if p.0 == ticket.priority %}<option value='{{ p.0 }}' selected='selected'>{{ p.1 }}</option>{% else %}<option value='{{ p.0 }}'>{{ p.1 }}</option>{% endif %}{% endfor %}</select></dd>

--- a/helpdesk/templates/helpdesk/ticket_list.html
+++ b/helpdesk/templates/helpdesk/ticket_list.html
@@ -111,7 +111,7 @@
                                 </optgroup>
                                 <optgroup label='{% trans "Assign To" %}'>
                                     <option value='unassign'>{% trans "Nobody (Unassign)" %}</option>
-                                    {% for u in user_choices %}
+                                    {% for u in assignable_users %}
                                         <option value='assign_{{ u.id }}'>{{ u.get_username }}</option>
                                     {% endfor %}
                                 </optgroup>

--- a/helpdesk/update_ticket.py
+++ b/helpdesk/update_ticket.py
@@ -299,7 +299,7 @@ def update_ticket(
         f.ticketchange_set.create(
             field=_("Owner"),
             old_value=old_owner,
-            new_value=ticket.assigned_to,
+            new_value=ticket.assigned_to if ticket.assigned_to else _("Unassigned"),
         )
 
     if priority != ticket.priority:

--- a/helpdesk/views/staff.py
+++ b/helpdesk/views/staff.py
@@ -56,7 +56,11 @@ from helpdesk.forms import (
     TicketResolvesForm,
     UserSettingsForm,
 )
-from helpdesk.lib import queue_template_context, safe_template_context, get_active_users
+from helpdesk.lib import (
+    queue_template_context,
+    safe_template_context,
+    get_assignable_users,
+)
 from helpdesk.models import (
     Checklist,
     ChecklistTask,
@@ -133,7 +137,9 @@ def get_user_queues(user) -> dict[str, str]:
 
 def get_form_extra_kwargs(user) -> dict[str, object]:
     return {
-        "active_users": get_active_users(),
+        "assignable_users": get_assignable_users(
+            helpdesk_settings.HELPDESK_STAFF_ONLY_TICKET_OWNERS
+        ),
         "queues": get_user_queues(user),
         "priorities": Ticket.PRIORITY_CHOICES,
     }
@@ -1177,7 +1183,9 @@ def ticket_list(request):
         dict(
             context,
             default_tickets_per_page=request.user.usersettings_helpdesk.tickets_per_page,
-            user_choices=User.objects.filter(is_active=True, is_staff=True),
+            assignable_users=get_assignable_users(
+                helpdesk_settings.HELPDESK_STAFF_ONLY_TICKET_OWNERS
+            ),
             kb_items=kbitem,
             queue_choices=huser.get_queues(),
             status_choices=Ticket.STATUS_CHOICES,


### PR DESCRIPTION
There was a bug when changing ticket owner to unassigned. It was transforming id 0 to -1 when calling update_ticket function.

I think it could be great to remove the use of magic values like -1 since it is prone to bugs like this.

I also refactored get_active_users() into lib.py file in order to reuse it in forms.py.