### PR TITLE
Migrations made reversible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,8 @@ demo/demodesk/media/helpdesk/attachments/DH-3/3/*
 demo/demodesk/media/helpdesk/attachments/DH-3/4/*
 !demo/demodesk/media/helpdesk/attachments/DH-3/3/someinfo.txt
 !demo/demodesk/media/helpdesk/attachments/DH-3/4/helpdesk.png
+
+# Devbox
+.devbox 
+devbox.lock
+devbox.json

--- a/helpdesk/migrations/0019_ticket_secret_key.py
+++ b/helpdesk/migrations/0019_ticket_secret_key.py
@@ -12,6 +12,13 @@ def clear_secret_keys(apps, schema_editor):
         ticket.save()
 
 
+def no_op(apps, schema_editor):
+    """
+    This is added only to make migrations reversible.
+    """
+    pass
+
+
 class Migration(migrations.Migration):
     dependencies = [
         ("helpdesk", "0018_ticket_secret_key"),
@@ -27,5 +34,5 @@ class Migration(migrations.Migration):
                 verbose_name="Secret key needed for viewing/editing ticket by non-logged in users",
             ),
         ),
-        migrations.RunPython(clear_secret_keys),
+        migrations.RunPython(clear_secret_keys, reverse_code=no_op),
     ]

--- a/helpdesk/migrations/0020_depickle_user_settings.py
+++ b/helpdesk/migrations/0020_depickle_user_settings.py
@@ -3,18 +3,20 @@ from django.db import migrations, models
 import helpdesk.models
 
 
+try:
+    import pickle
+except ImportError:
+    import cPickle as pickle  # pyright: ignore[reportMissingImports]
+try:
+    # Python 2 support
+    from base64 import urlsafe_b64decode as b64decode
+except ImportError:
+    # Python 3 support
+    from base64 import decodebytes as b64decode
+
+
+# return a python dictionary representing the pickled data.
 def unpickle_settings(settings_pickled):
-    # return a python dictionary representing the pickled data.
-    try:
-        import pickle
-    except ImportError:
-        import cPickle as pickle
-    try:
-        # Python 2 support
-        from base64 import urlsafe_b64decode as b64decode
-    except ImportError:
-        # Python 3 support
-        from base64 import decodebytes as b64decode
     try:
         return pickle.loads(b64decode(settings_pickled.encode("utf-8")))
     except Exception:
@@ -30,6 +32,24 @@ def move_old_values(apps, schema_editor):
             settings_dict = unpickle_settings(user_settings.settings_pickled)
             for setting, value in settings_dict.items():
                 user_settings.__setattr__(setting, value)
+
+
+def pickle_settings(apps, schema_editor):
+    """
+    Pickle settings back to the old format. This is necessary for reversing this migration.
+    """
+    UserSettings = apps.get_model("helpdesk", "UserSettings")
+    db_alias = schema_editor.connection.alias
+    for user_settings in UserSettings.objects.using(db_alias).all():
+        settings_dict = {
+            "email_on_ticket_assign": user_settings.email_on_ticket_assign,
+            "email_on_ticket_change": user_settings.email_on_ticket_change,
+            "login_view_ticketlist": user_settings.login_view_ticketlist,
+            "tickets_per_page": user_settings.tickets_per_page,
+            "use_email_as_submitter": user_settings.use_email_as_submitter,
+        }
+        user_settings.settings_pickled = pickle.dumps(settings_dict)
+        user_settings.save()
 
 
 class Migration(migrations.Migration):
@@ -52,7 +72,8 @@ class Migration(migrations.Migration):
             name="email_on_ticket_change",
             field=models.BooleanField(
                 default=helpdesk.models.email_on_ticket_change_default,
-                help_text="If you're the ticket owner and the ticket is changed via the web by somebody else, do you want to receive an e-mail?",
+                help_text="If you're the ticket owner and the ticket is changed via the web by somebody else, "
+                "do you want to receive an e-mail?",
                 verbose_name="E-mail me on ticket change?",
             ),
         ),
@@ -80,7 +101,9 @@ class Migration(migrations.Migration):
             name="use_email_as_submitter",
             field=models.BooleanField(
                 default=helpdesk.models.use_email_as_submitter_default,
-                help_text="When you submit a ticket, do you want to automatically use your e-mail address as the submitter address? You can type a different e-mail address when entering the ticket if needed, this option only changes the default.",
+                help_text="When you submit a ticket, do you want to automatically use your e-mail address as the "
+                "submitter address? You can type a different e-mail address when entering the ticket if needed, "
+                "this option only changes the default.",
                 verbose_name="Use my e-mail address when submitting tickets?",
             ),
         ),
@@ -89,10 +112,11 @@ class Migration(migrations.Migration):
             name="settings_pickled",
             field=models.TextField(
                 blank=True,
-                help_text="DEPRECATED! This is a base64-encoded representation of a pickled Python dictionary. Do not change this field via the admin.",
+                help_text="DEPRECATED! This is a base64-encoded representation of a pickled Python dictionary. Do not "
+                "change this field via the admin.",
                 null=True,
                 verbose_name="DEPRECATED! Settings Dictionary DEPRECATED!",
             ),
         ),
-        migrations.RunPython(move_old_values),
+        migrations.RunPython(move_old_values, reverse_code=pickle_settings),
     ]


### PR DESCRIPTION
This resolves #1291 

Some migrations are not reversible, which makes it impossible to uninstall the application in a "django way". I have added a "no_op" function for migration 19 to make it reversible. As a matter of fact, this migration calls a function to clean up the ticket's secret key. But reversing it will remove the column, so there is no need to add information to the underlying column because of it.

Migration 20 depickles an old column that had settings pickled. So, the reverse method is to pickle that back again, although I doubt that someone would want to undo this particular migration. But, for the sake of consistency, it is important to have it undoing whatever is the operation that was carried out.

I have tested it by migrating and "unmigrating", one migration at a time and the whole thing at once, to be sure both migrations are working as expected. 