### PR TITLE
BUG: Update Dockerfile UV needs README.rst

### DIFF
--- a/standalone/Dockerfile
+++ b/standalone/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get install -yqq \
    cron \
    git
 
-COPY django-helpdesk/src django-helpdesk/standalone django-helpdesk/pyproject.toml /opt/django-helpdesk
+COPY django-helpdesk/src django-helpdesk/standalone django-helpdesk/pyproject.toml django-helpdesk/README.rst /opt/django-helpdesk
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 RUN pip3 install --upgrade pip
 RUN pip3 install packaging


### PR DESCRIPTION
Our image build job is failing. pyproject.toml requires README.rst. Copying it in here. 