### PR TITLE
Switch to trust based publishing mechanism and fix SPDX short identifier for license.

### DIFF
--- a/.github/workflows/release_to_pypi.yml
+++ b/.github/workflows/release_to_pypi.yml
@@ -8,6 +8,11 @@ jobs:
   build-n-publish:
     name: Build and publish to PyPI
     runs-on: ubuntu-latest
+    # Specifying a GitHub environment is optional, but strongly encouraged
+    environment: release
+    permissions:
+      # IMPORTANT: this permission is mandatory for Trusted Publishing
+      id-token: write
 
     steps:
       - name: Checkout source
@@ -27,7 +32,3 @@ jobs:
           twine check --strict dist/*
       - name: Publish distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "django-helpdesk"
-version = "2.0.0"
+version = "2.0.1"
 description = "Django-powered ticket tracker for your helpdesk"
 authors = [
     {name = "Ross Poulton", email = "ross@rossp.org"},
 ]
 requires-python = ">=3.9"
 readme = "README.rst"
-license = {text = "BSD3"}
+license = {text = "BSD-3-Clause"}
 keywords = ["django", "helpdesk", "django-helpdesk", "tickets", "incidents", "cases", "bugs", "track", "support"]
 maintainers = [
     {name = "Christopher Broderick", email = "uhurusurfa@gmail.com"},
@@ -46,7 +46,7 @@ classifiers = [
     "Framework :: Django :: 4.0",
     "Framework :: Django :: 5.0",
     "Intended Audience :: Customer Service",
-    "License :: OSI Approved :: BSD-3 License",
+    "License :: OSI Approved :: BSD-3-Clause License",
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Programming Language :: Python",


### PR DESCRIPTION
1. Change to using the trust based PyPi publish mechanism
2. Set the license to the correct SPDX string.