### PR TITLE
Fix crash in UpdateTicketView when unauthenticated user logs in after redirect

### DIFF
--- a/src/helpdesk/views/staff.py
+++ b/src/helpdesk/views/staff.py
@@ -1322,15 +1322,19 @@ class UpdateTicketView(
         extra = get_form_extra_kwargs(self.request.user)
         kwargs.update(extra)
         # Copy all data submitted that is not in the forms defined fields
-        form_fields = kwargs["form"].base_fields
-        all_fields = kwargs["form"].data
-        self.extra_context = {
-            "xform": {
-                k: v
-                for k, v in all_fields.items()
-                if k != "csrfmiddlewaretoken" and k not in form_fields
+        form = kwargs.get("form")
+        if form is not None and hasattr(form, "data") and form.data:
+            form_fields = form.base_fields
+            all_fields = form.data
+            self.extra_context = {
+                "xform": {
+                    k: v
+                    for k, v in all_fields.items()
+                    if k != "csrfmiddlewaretoken" and k not in form_fields
+                }
             }
-        }
+        else:
+            self.extra_context = {"xform": {}}
         return super().get_context_data(**kwargs)
 
     def get_form_kwargs(self):

--- a/tests/test_update_ticket_view.py
+++ b/tests/test_update_ticket_view.py
@@ -1,0 +1,37 @@
+from django.test import TestCase
+from django.urls import reverse
+from django.contrib.auth import get_user_model
+from helpdesk.models import Queue, Ticket
+
+User = get_user_model()
+
+
+class UpdateTicketViewTests(TestCase):
+    def setUp(self):
+        self.queue = Queue.objects.create(title="Test Queue", slug="test")
+        self.user = User.objects.create_user(
+            username="testuser", password="pass123", is_staff=True
+        )
+
+        # Create a sample ticket
+        self.ticket = Ticket.objects.create(
+            title="Sample ticket", queue=self.queue, submitter_email="test@example.com"
+        )
+
+    def test_redirect_after_login_does_not_crash(self):
+        """If unauthenticated user tries to update a ticket, they should
+        be redirected to login, and after login, no crash should occur.
+        """
+        url = reverse("helpdesk:update", kwargs={"ticket_id": self.ticket.id})
+
+        # Try to access update page without login
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 302)  # redirect to login
+
+        # Log in
+        self.client.login(username="testuser", password="pass123")
+
+        # Try accessing again (simulating redirect after login)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Sample ticket")


### PR DESCRIPTION
### Problem
When an unauthenticated user tries to add a comment/resolution, they are redirected to login. After login, the redirect caused a 500 error because UpdateTicketView accessed form.data on a GET request.

### Solution
Added a safe check in get_context_data to only access form.data if it exists. Otherwise, provide an empty dict.

### Tests
Added regression test to confirm:
- Unauthenticated users are redirected to login.
- After login, the update page loads successfully (status 200).

### Related Issue
Closes #1315

### Future Work
It might be possible to preserve the entered comment/attachments across login using session storage or temporary persistence. This PR does not address that, but I’d be happy to explore it in a follow-up if maintainers are interested.