### PR TITLE
Fix missing custom fields in UpdateTicketView after validation errors

### DIFF
--- a/src/helpdesk/views/staff.py
+++ b/src/helpdesk/views/staff.py
@@ -1335,7 +1335,12 @@ class UpdateTicketView(
             }
         else:
             self.extra_context = {"xform": {}}
-        return super().get_context_data(**kwargs)
+        context = super().get_context_data(**kwargs)
+        ticket = self.get_object()
+        context["customfields_form"] = EditTicketCustomFieldForm(
+            self.request.POST or None, instance=ticket
+        )
+        return context
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()

--- a/tests/test_update_ticket_view.py
+++ b/tests/test_update_ticket_view.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 from django.urls import reverse
 from django.contrib.auth import get_user_model
-from helpdesk.models import Queue, Ticket
+from helpdesk.models import Queue, Ticket, CustomField
 
 User = get_user_model()
 
@@ -35,3 +35,48 @@ class UpdateTicketViewTests(TestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Sample ticket")
+
+
+class UpdateTicketCustomFieldsTests(TestCase):
+    def setUp(self):
+        self.queue = Queue.objects.create(title="Test Queue", slug="test")
+        self.user = User.objects.create_user(
+            username="testuser",
+            password="pass123",
+            is_staff=True,
+        )
+
+        self.ticket = Ticket.objects.create(
+            title="Sample ticket", queue=self.queue, submitter_email="test@example.com"
+        )
+
+        self.custom_field = CustomField.objects.create(
+            name="extra_info",
+            label="Extra Info",
+            data_type="varchar",
+            max_length=50,
+            required=False,
+        )
+
+    def test_custom_field_persists_after_invalid_post(self):
+        """Custom fields should still be shown after form validation errors."""
+
+        url = reverse("helpdesk:update", kwargs={"ticket_id": self.ticket.id})
+
+        self.client.login(username="testuser", password="pass123")
+
+        response = self.client.get(url)
+        self.assertContains(response, "Extra Info")
+
+        response = self.client.post(
+            url,
+            {
+                "queue": self.queue.id,
+                # "title" missing
+                "body": "Test body",
+                "priority": 3,
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "There are errors in the form")
+        self.assertContains(response, "Extra Info")


### PR DESCRIPTION
### Problem
When a ticket has custom fields, they display correctly on the first load (`/tickets/<id>/` via `view_ticket`).  
However, if invalid data is submitted on the update form, the page reloads with errors but the custom fields disappear.  
This happens because `UpdateTicketView` did not provide `customfields_form` to the template, unlike `view_ticket`.

### Solution
- Updated `UpdateTicketView.get_context_data` to always pass `customfields_form` (using `EditTicketCustomFieldForm`).  
- This ensures that custom fields remain visible both on initial GET and after POST with validation errors.

### Tests
Added a regression test:
  - Creates a custom field.
  - Confirms it is visible on the initial view (`helpdesk:view`).
  - Submits invalid data to `helpdesk:update`.
  - Confirms the page shows validation errors *and* the custom field is still visible.

### Related Issue
Closes #1318 

