### PR TITLE
Make sure entrypoint script is executable

### DIFF
--- a/standalone/Dockerfile
+++ b/standalone/Dockerfile
@@ -48,4 +48,6 @@ RUN DJANGO_HELPDESK_SECRET_KEY=foo python3 manage.py collectstatic --noinput
 
 RUN echo "* * * * * root . /etc/env && /usr/local/bin/python3 /opt/django-helpdesk/standalone/manage.py get_email >> /var/log/cron.log 2>&1" > /etc/crontab
 RUN chmod 0644 /etc/crontab
+# Make sure entrypoint script is executable
+RUN chmod +x /opt/django-helpdesk/standalone/entrypoint.sh
 ENTRYPOINT [ "/opt/django-helpdesk/standalone/entrypoint.sh" ]


### PR DESCRIPTION
The ENTRYPOINT requires that the script is executable if referenced directly in order for the container to be started.
Alternative is to use `["sh", "/path/to/entrypoint.sh"]`