### PR TITLE
fix: show password change link to all authenticated users

### DIFF
--- a/src/helpdesk/templates/helpdesk/navigation-header.html
+++ b/src/helpdesk/templates/helpdesk/navigation-header.html
@@ -48,7 +48,7 @@
           <div class="dropdown-menu dropdown-menu-end" aria-labelledby="userDropdown">
             <a class="dropdown-item" href="{% url 'helpdesk:user_settings' %}"><i class="fas fa-fw fa-user-cog"></i> {% trans "User Settings" %}</a>
             <a class="dropdown-item" href='{% url 'helpdesk:rss_index' %}'><i class="fas fa-fw fa-rss-square"></i> {% trans "RSS Feeds" %}</a>
-            {% if helpdesk_settings.HELPDESK_SHOW_CHANGE_PASSWORD and user.has_usable_password %}
+            {% if user.is_authenticated and user.has_usable_password %}
             <a class="dropdown-item" href="{% url 'helpdesk:password_change' %}"><i class="fas fa-fw fa-user-secret"></i> {% trans "Change password" %}</a>
             {% endif %}
             <div class="dropdown-divider"></div>


### PR DESCRIPTION
Fixes #745

## Problem
Non-staff users had no way to change their password because the 
"Change password" link in the navigation was gated behind the 
HELPDESK_SHOW_CHANGE_PASSWORD setting, which defaults to False.

## Solution
Replaced the setting condition with `user.is_authenticated` so all 
logged-in users with a usable password can see and access the 
password change page.

## Changes
- `src/helpdesk/templates/helpdesk/navigation-header.html`: updated 
  the condition on the change password link