### PR TITLE
Cleanup redundant documentation and make teams mode default to off

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,14 +26,14 @@ help:
 .PHONY: develop
 develop:
 	$(UV) venv
-	$(UV) sync --all-extras --dev --group test
+	$(UV) sync --dev --group test
 	$(UV) tool install pre-commit --with pre-commit-uv --force-reinstall
 	pre-commit install
 
 #: sync - Synchronize the environment with the project configuration
 .PHONY: sync
 sync:
-	$(UV) sync --all-extras --dev --group test
+	$(UV) sync --dev --group test
 
 
 #: clean - Basic cleanup, mostly temporary files.
@@ -106,7 +106,7 @@ readme:
 demo:
 	yarn install
 	make static-vendor
-	uv  sync  --all-extras --dev --group test --group teams
+	uv  sync --dev --group test
 	uv run manage.py migrate --noinput
 	# Install fixtures
 	uv run manage.py loaddata emailtemplate.json

--- a/demodesk/config/settings.py
+++ b/demodesk/config/settings.py
@@ -33,9 +33,9 @@ ALLOWED_HOSTS = []
 # an internal demo you don't need such security, but please
 # remember when setting up your own development / production server!
 
-# Default teams mode to enabled unless overridden by an environment variable set to "false"
+# Default teams mode to disabled unless overridden by an environment variable set to "false"
 HELPDESK_TEAMS_MODE_ENABLED = (
-    os.getenv("HELPDESK_TEAMS_MODE_ENABLED", "true").lower() == "true"
+    os.getenv("HELPDESK_TEAMS_MODE_ENABLED", "false").lower() == "true"
 )
 
 # Application definition

--- a/demodesk/config/settings.py
+++ b/demodesk/config/settings.py
@@ -120,9 +120,6 @@ HELPDESK_KB_ENABLED = True
 
 HELPDESK_TICKETS_TIMELINE_ENABLED = True
 
-# Allow users to change their passwords
-HELPDESK_SHOW_CHANGE_PASSWORD = True
-
 # Instead of showing the public web portal first,
 # we can instead redirect users straight to the login page.
 HELPDESK_REDIRECT_TO_LOGIN_BY_DEFAULT = False

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -102,10 +102,6 @@ These changes are visible throughout django-helpdesk
 
   **Default:** ``HELPDESK_TRANSLATE_TICKET_COMMENTS_LANG = ["en", "de", "fr", "it", "ru"]``
 
-- **HELPDESK_SHOW_CHANGE_PASSWORD** Show link to 'change password' on 'User Settings' page?
-
-  **Default:** ``HELPDESK_SHOW_CHANGE_PASSWORD = False``
-
 - **HELPDESK_FOLLOWUP_MOD** Allow user to override default layout for 'followups' (work in progress)
 
   **Default:** ``HELPDESK_FOLLOWUP_MOD = False``

--- a/docs/standalone.rst
+++ b/docs/standalone.rst
@@ -144,7 +144,6 @@ Configuration for Production Use
 |----------|---------|-------------|
 | ```HELPDESK_KB_ENABLED``` | ```True``` | Enable knowledge base |
 | ```HELPDESK_TICKETS_TIMELINE_ENABLED``` | ```True``` | Enable ticket timeline |
-| ```HELPDESK_SHOW_CHANGE_PASSWORD``` | ```True``` | Allow users to change passwords |
 
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "django-helpdesk"
-version = "2.1.1"
+version = "2.2.0"
 description = "Django-powered ticket tracker for your helpdesk"
 authors = [
     {name = "Ross Poulton", email = "ross@rossp.org"},

--- a/src/helpdesk/settings.py
+++ b/src/helpdesk/settings.py
@@ -114,11 +114,6 @@ HELPDESK_TRANSLATE_TICKET_COMMENTS_LANG = getattr(
     ["en", "de", "es", "fr", "it", "ru"],
 )
 
-# show link to 'change password' on 'User Settings' page?
-HELPDESK_SHOW_CHANGE_PASSWORD = getattr(
-    settings, "HELPDESK_SHOW_CHANGE_PASSWORD", False
-)
-
 # allow user to override default layout for 'followups' - work in progress.
 HELPDESK_FOLLOWUP_MOD = getattr(settings, "HELPDESK_FOLLOWUP_MOD", False)
 

--- a/standalone/config/settings.py
+++ b/standalone/config/settings.py
@@ -48,13 +48,23 @@ INSTALLED_APPS = [
     "django.contrib.sites",
     "django.contrib.humanize",
     "bootstrap4form",
-    "account",  # Required by pinax-teams
-    "pinax.invitations",  # required by pinax-teams
-    "pinax.teams",  # team support
-    "reversion",  # required by pinax-teams
     "helpdesk",  # This is us!
     "rest_framework",  # required for the API
 ]
+
+# Default teams mode to disabled unless overridden by an environment variable set to "false"
+HELPDESK_TEAMS_MODE_ENABLED = (
+    os.getenv("HELPDESK_TEAMS_MODE_ENABLED", "false").lower() == "true"
+)
+if HELPDESK_TEAMS_MODE_ENABLED:
+    INSTALLED_APPS.extend(
+        [
+            "account",  # Required by pinax-teams
+            "pinax.invitations",  # required by pinax-teams
+            "pinax.teams",  # team support
+            "reversion",  # required by pinax-teams
+        ]
+    )
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",

--- a/standalone/config/settings.py
+++ b/standalone/config/settings.py
@@ -124,11 +124,6 @@ HELPDESK_TICKETS_TIMELINE_ENABLED = (
     os.environ.get("HELPDESK_TICKETS_TIMELINE_ENABLED", "True") == "True"
 )
 
-# Allow users to change their passwords
-HELPDESK_SHOW_CHANGE_PASSWORD = (
-    os.environ.get("HELPDESK_SHOW_CHANGE_PASSWORD", "True") == "True"
-)
-
 # Instead of showing the public web portal first,
 # we can instead redirect users straight to the login page.
 HELPDESK_REDIRECT_TO_LOGIN_BY_DEFAULT = (


### PR DESCRIPTION
The change password link was controlled by a setting named HELPDESK_SHOW_CHANGE_PASSWORD which was removed and the link is now always visible.
This PR removes all references to HELPDESK_SHOW_CHANGE_PASSWORD in the documentation.

Teams mode no longer enabled by default:

- Teams mode requires Pinax libraries which have not been maintained in a number of years and appear to be abandoned so the HELPDESK_TEAMS_MODE_ENABLED is defaulted to "false" now