### PR TITLE
Add follow-up sort order toggle to ticket view

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -229,6 +229,10 @@ Options that change ticket updates
 
   **Default:** ``HELPDESK_SHOW_CUSTOM_FIELDS_FOLLOW_UP_LIST = []``
 
+- **HELPDESK_FOLLOWUP_NEWEST_FIRST** Sets the default order for the follow-up list on the ticket view. If True, the most recent follow up is listed first. If False, the oldest follow up is listed first. Users can still toggle the order from the ticket view using the sort button, regardless of this setting.
+
+  **Default:** ``HELPDESK_FOLLOWUP_NEWEST_FIRST = False``
+
 Options that change ticket properties
 -------------------------------------
 

--- a/src/helpdesk/settings.py
+++ b/src/helpdesk/settings.py
@@ -302,6 +302,15 @@ HELPDESK_SHOW_CUSTOM_FIELDS_FOLLOW_UP_LIST = getattr(
     settings, "HELPDESK_SHOW_CUSTOM_FIELDS_FOLLOW_UP_LIST", []
 )
 
+# default order in which follow ups are listed on the ticket view.
+# If True, the most recent follow up is listed first (newest first).
+# If False, the oldest follow up is listed first (oldest first).
+# Users can still toggle the order from the ticket view regardless of this
+# setting.
+HELPDESK_FOLLOWUP_NEWEST_FIRST = getattr(
+    settings, "HELPDESK_FOLLOWUP_NEWEST_FIRST", False
+)
+
 # show delete buttons in ticket follow ups if user is 'superuser'
 HELPDESK_SHOW_DELETE_BUTTON_SUPERUSER_FOLLOW_UP = getattr(
     settings, "HELPDESK_SHOW_DELETE_BUTTON_SUPERUSER_FOLLOW_UP", False

--- a/src/helpdesk/templates/helpdesk/ticket.html
+++ b/src/helpdesk/templates/helpdesk/ticket.html
@@ -31,39 +31,56 @@
     </div>
   {% else %}
     {# Nav Tabs #}
-    <ul class="nav nav-underline ms-3" id="ticketTab" role="tablist">
-      <li class="nav-item" role="presentation">
-        <button class="nav-link active"
-                id="followup-tab"
-                data-bs-toggle="tab"
-                data-bs-target="#followup-tab-pane"
-                type="button"
-                role="tab"
-                aria-controls="followup-tab-pane"
-                aria-selected="true">{% translate "Follow ups" %}</button>
-      </li>
-      <li class="nav-item" role="presentation">
-        <button class="nav-link"
-                id="respond-tab"
-                data-bs-toggle="tab"
-                data-bs-target="#respond-tab-pane"
-                type="button"
-                role="tab"
-                aria-controls="respond-tab-pane"
-                aria-selected="false">{% translate "Respond" %}</button>
-      </li>
-    </ul>
+    <div class="d-flex justify-content-between align-items-center me-3">
+      <ul class="nav nav-underline ms-3" id="ticketTab" role="tablist">
+        <li class="nav-item" role="presentation">
+          <button class="nav-link active"
+                  id="followup-tab"
+                  data-bs-toggle="tab"
+                  data-bs-target="#followup-tab-pane"
+                  type="button"
+                  role="tab"
+                  aria-controls="followup-tab-pane"
+                  aria-selected="true">{% translate "Follow ups" %}</button>
+        </li>
+        <li class="nav-item" role="presentation">
+          <button class="nav-link"
+                  id="respond-tab"
+                  data-bs-toggle="tab"
+                  data-bs-target="#respond-tab-pane"
+                  type="button"
+                  role="tab"
+                  aria-controls="respond-tab-pane"
+                  aria-selected="false">{% translate "Respond" %}</button>
+        </li>
+      </ul>
+      {% if followups %}
+        <button type="button"
+                id="followup-sort-toggle"
+                class="btn btn-light btn-sm"
+                data-order="{% if helpdesk_settings.HELPDESK_FOLLOWUP_NEWEST_FIRST %}newest_first{% else %}oldest_first{% endif %}">
+          <i class="fa-solid fa-arrow-down-short-wide me-1"></i>
+          <span id="followup-sort-toggle-label">
+            {% if helpdesk_settings.HELPDESK_FOLLOWUP_NEWEST_FIRST %}
+              {% translate "Newest first" %}
+            {% else %}
+              {% translate "Oldest first" %}
+            {% endif %}
+          </span>
+        </button>
+      {% endif %}
+    </div>
     <div class="tab-content" id="myTabContent">
       {# Followup Pane #}
-      {% if ticket.followup_set.all %}
+      {% if followups %}
         {% load ticket_to_link %}
         <div class="tab-pane fade show active"
              id="followup-tab-pane"
              role="tabpanel"
              aria-labelledby="followup-tab"
              tabindex="0">
-          <div class="list-group list-group-flush my-3">
-            {% for followup in ticket.followup_set.all %}
+          <div class="list-group list-group-flush my-3" id="followup-list">
+            {% for followup in followups %}
               <div class="list-group-item list-group-item-action">
                 <div class="d-flex align-items-center">
                   <h6 class="mb-0">{{ followup.title|escape|num_to_link }}</h6>
@@ -431,6 +448,20 @@ $( function() {
 
       document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(function(el) {
           new bootstrap.Tooltip(el);
+      });
+
+      // Toggle follow ups between oldest-first and newest-first order.
+      $('#followup-sort-toggle').on('click', function() {
+          var $button = $(this);
+          var $list = $('#followup-list');
+          $list.children().get().reverse().forEach(function(item) {
+              $list.append(item);
+          });
+
+          var newOrder = $button.data('order') === 'newest_first' ? 'oldest_first' : 'newest_first';
+          var label = newOrder === 'newest_first' ? '{% translate "Newest first" %}' : '{% translate "Oldest first" %}';
+          $button.data('order', newOrder);
+          $('#followup-sort-toggle-label').text(label);
       });
 
       {% if helpdesk_settings.HELPDESK_ENABLE_ATTACHMENTS %}

--- a/src/helpdesk/views/staff.py
+++ b/src/helpdesk/views/staff.py
@@ -443,6 +443,12 @@ def followup_delete(request, ticket_id, followup_id):
 followup_delete = staff_member_required(followup_delete)
 
 
+def get_followups_for_ticket(ticket):
+    """Returns the ticket's follow ups, ordered per HELPDESK_FOLLOWUP_NEWEST_FIRST."""
+    order = "-date" if helpdesk_settings.HELPDESK_FOLLOWUP_NEWEST_FIRST else "date"
+    return ticket.followup_set.order_by(order)
+
+
 @helpdesk_staff_member_required
 def view_ticket(request, ticket_id):
     ticket = get_object_or_404(Ticket, id=ticket_id)
@@ -522,6 +528,7 @@ def view_ticket(request, ticket_id):
         "helpdesk/ticket.html",
         {
             "ticket": ticket,
+            "followups": get_followups_for_ticket(ticket),
             "dependencies": dependencies,
             "submitter_userprofile_url": submitter_userprofile_url,
             "form": form,
@@ -1388,6 +1395,7 @@ class UpdateTicketView(
         context["customfields_form"] = EditTicketCustomFieldForm(
             self.request.POST or None, instance=ticket
         )
+        context["followups"] = get_followups_for_ticket(ticket)
         return context
 
     def get_form_kwargs(self):


### PR DESCRIPTION
Follow-ups on the ticket page were hardcoded to render oldest-first (FollowUp.Meta.ordering) with no way to change it. Add a button next to the Follow ups/Respond tabs that reverses the list client-side, and a HELPDESK_FOLLOWUP_NEWEST_FIRST setting (default False) to control the initial order, documented in docs/settings.rst.