### PR TITLE
Attachment list is now collapsible on ticket_desc_table.html

### DIFF
--- a/src/helpdesk/templates/helpdesk/include/attachment_list_item.html
+++ b/src/helpdesk/templates/helpdesk/include/attachment_list_item.html
@@ -1,0 +1,11 @@
+{% load i18n %}
+<li class="list-group-item ps-0">
+  <a class="d-block" href="{{ attachment.file.url }}" target="_blank">{{ attachment.filename|truncatechars:40 }}</a>
+  <small class="text-secondary">({{ attachment.mime_type }}, {{ attachment.size|filesizeformat }})</small>
+  {% if attachment.followup.user and request.user == attachment.followup.user %}
+    <a href="{% url 'helpdesk:attachment_del' ticket.id attachment.id %}"
+       class="text-secondary">
+      <i class="fa-regular fa-trash-can fa-sm ms-2"></i>
+    </a>
+  {% endif %}
+</li>

--- a/src/helpdesk/templates/helpdesk/ticket_desc_table.html
+++ b/src/helpdesk/templates/helpdesk/ticket_desc_table.html
@@ -275,22 +275,34 @@
       {% if helpdesk_settings.HELPDESK_ENABLE_ATTACHMENTS %}
         <div class="col">
           <small class="text-uppercase text-secondary">{% translate "Attachments" %}</small>
-          <ul class="list-group list-group-flush">
-            {% for followup in ticket.followup_set.all %}
-              {% for attachment in followup.followupattachment_set.all %}
-                <li class="list-group-item ps-0">
-                  <a class="d-block" href="{{ attachment.file.url }}" target="_blank">{{ attachment.filename|truncatechars:40 }}</a>
-                  <small class="text-secondary">({{ attachment.mime_type }}, {{ attachment.size|filesizeformat }})</small>
-                  {% if followup.user and request.user == followup.user %}
-                    <a href="{% url 'helpdesk:attachment_del' ticket.id attachment.id %}"
-                       class="text-secondary">
-                      <i class="fa-regular fa-trash-can fa-sm ms-2"></i>
-                    </a>
-                  {% endif %}
-                </li>
+          {% with recent_attachments=ticket_attachments|slice:":3" older_attachments=ticket_attachments|slice:"3:" %}
+            <ul class="list-group list-group-flush">
+              {% for attachment in recent_attachments %}
+                {% include "helpdesk/include/attachment_list_item.html" %}
+              {% empty %}
+                <small>{% translate "No attachments" %}</small>
               {% endfor %}
-            {% endfor %}
-          </ul>
+            </ul>
+            {% if older_attachments %}
+              <a class="link-secondary small"
+                 data-bs-toggle="collapse"
+                 href="#olderAttachments"
+                 role="button"
+                 aria-expanded="false"
+                 aria-controls="olderAttachments"
+                 onclick="$(this).find('i').toggleClass('fa-caret-down fa-caret-up')">
+                {% blocktranslate count counter=older_attachments|length %}Show {{ counter }} older attachment{% plural %}Show {{ counter }} older attachments{% endblocktranslate %}
+                <i class="fas fa-caret-down"></i>
+              </a>
+              <div class="collapse" id="olderAttachments">
+                <ul class="list-group list-group-flush">
+                  {% for attachment in older_attachments %}
+                    {% include "helpdesk/include/attachment_list_item.html" %}
+                  {% endfor %}
+                </ul>
+              </div>
+            {% endif %}
+          {% endwith %}
         </div>
       {% endif %}
       <div class="col">

--- a/src/helpdesk/views/staff.py
+++ b/src/helpdesk/views/staff.py
@@ -380,6 +380,7 @@ def followup_edit(request, ticket_id, followup_id):
                 "ticket": ticket,
                 "form": form,
                 "ticketcc_string": ticketcc_string,
+                "ticket_attachments": get_attachments_for_ticket(ticket),
             },
         )
     elif request.method == "POST":
@@ -447,6 +448,15 @@ def get_followups_for_ticket(ticket):
     """Returns the ticket's follow ups, ordered per HELPDESK_FOLLOWUP_NEWEST_FIRST."""
     order = "-date" if helpdesk_settings.HELPDESK_FOLLOWUP_NEWEST_FIRST else "date"
     return ticket.followup_set.order_by(order)
+
+
+def get_attachments_for_ticket(ticket):
+    """Returns all of the ticket's attachments across its follow ups, most recent first."""
+    return (
+        FollowUpAttachment.objects.filter(followup__ticket=ticket)
+        .select_related("followup")
+        .order_by("-id")
+    )
 
 
 @helpdesk_staff_member_required
@@ -530,6 +540,7 @@ def view_ticket(request, ticket_id):
             "ticket": ticket,
             "followups": get_followups_for_ticket(ticket),
             "dependencies": dependencies,
+            "ticket_attachments": get_attachments_for_ticket(ticket),
             "submitter_userprofile_url": submitter_userprofile_url,
             "form": form,
             "preset_replies": PreSetReply.objects.filter(

--- a/src/helpdesk/views/staff.py
+++ b/src/helpdesk/views/staff.py
@@ -1407,6 +1407,7 @@ class UpdateTicketView(
             self.request.POST or None, instance=ticket
         )
         context["followups"] = get_followups_for_ticket(ticket)
+        context["ticket_attachments"] = get_attachments_for_ticket(ticket)
         return context
 
     def get_form_kwargs(self):

--- a/tests/test_staff_ticket_view.py
+++ b/tests/test_staff_ticket_view.py
@@ -1,11 +1,12 @@
 from http import HTTPStatus
 
 from django.contrib.auth import get_user_model
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
 from django.urls import resolve, reverse
 
 from helpdesk.forms import CreateChecklistForm, EditTicketCustomFieldForm, TicketForm
-from helpdesk.models import Queue, Ticket
+from helpdesk.models import FollowUp, FollowUpAttachment, Queue, Ticket
 
 User = get_user_model()
 
@@ -86,3 +87,30 @@ class StaffTicketViewTests(TestCase):
         self.assertEqual(r.status_code, HTTPStatus.OK)
         self.assertRedirects(r, self.url)
         self.assertEqual(self.ticket.assigned_to, self.staff_user)
+
+    def _add_attachments(self, count):
+        followup = FollowUp.objects.create(ticket=self.ticket, title="Followup")
+        for i in range(count):
+            FollowUpAttachment.objects.create(
+                followup=followup,
+                file=SimpleUploadedFile(f"file{i}.txt", b"content"),
+            )
+
+    def test_few_attachments_shown_without_collapse(self):
+        self.client.force_login(self.staff_user)
+        self._add_attachments(3)
+
+        r = self.client.get(self.url)
+
+        self.assertEqual(r.context["ticket_attachments"].count(), 3)
+        self.assertNotContains(r, "older attachment")
+
+    def test_many_attachments_are_collapsed(self):
+        self.client.force_login(self.staff_user)
+        self._add_attachments(8)
+
+        r = self.client.get(self.url)
+
+        self.assertEqual(r.context["ticket_attachments"].count(), 8)
+        self.assertContains(r, "Show 5 older attachments")
+        self.assertContains(r, 'id="olderAttachments"')


### PR DESCRIPTION
Attachment list is now collapsible so that many attachments can be added without clustering the ticket update page.

Fixes #1355 