### PR TITLE
Fix submitter email template always using "updated" regardless of ticket status

### DIFF
--- a/src/helpdesk/update_ticket.py
+++ b/src/helpdesk/update_ticket.py
@@ -145,12 +145,10 @@ def process_email_notifications_for_ticket_update(
             or (follow_up.new_status in (Ticket.RESOLVED_STATUS, Ticket.CLOSED_STATUS))
         )
     ):
-        # Use hard coded prefix for submitter updates on  tickets for backwards compatibility
-        # TODO: possibly make the template prefix modification configurable
         messages_sent_to.update(
             ticket.send(
                 {
-                    "submitter": ("updated_submitter", context),
+                    "submitter": (template_prefix + "submitter", context),
                 },
                 dont_send_to=messages_sent_to,
                 fail_silently=True,

--- a/src/helpdesk/update_ticket.py
+++ b/src/helpdesk/update_ticket.py
@@ -145,10 +145,11 @@ def process_email_notifications_for_ticket_update(
             or (follow_up.new_status in (Ticket.RESOLVED_STATUS, Ticket.CLOSED_STATUS))
         )
     ):
+        submitter_prefix = "updated_" if reassigned else template_prefix
         messages_sent_to.update(
             ticket.send(
                 {
-                    "submitter": (template_prefix + "submitter", context),
+                    "submitter": (submitter_prefix + "submitter", context),
                 },
                 dont_send_to=messages_sent_to,
                 fail_silently=True,


### PR DESCRIPTION
When a ticket is resolved or closed, the submitter email subject showed the wrong status because the template name was hardcoded to "updated_submitter". Use the same template_prefix logic already applied to owner/cc notifications.
