### PR TITLE
feat: expose all sortable columns in ticket list sorting filter

### DIFF
--- a/src/helpdesk/query.py
+++ b/src/helpdesk/query.py
@@ -117,6 +117,29 @@ def _validate_sorting(sorting):
         raise SuspiciousOperation(f"Disallowed sort field: {sorting}")
 
 
+def last_followup_subquery():
+    """
+    The most recent FollowUp date per ticket, so that the queryset can be
+    annotated before ordering by ``last_followup`` (which is not a real model
+    field, see __run__).
+    """
+    return Subquery(
+        FollowUp.objects.order_by()
+        .annotate(
+            last_followup=Window(
+                expression=Max("date"),
+                partition_by=[
+                    F("ticket_id"),
+                ],
+                order_by="-date",
+            )
+        )
+        .filter(ticket_id=OuterRef("id"))
+        .values("last_followup")
+        .distinct()
+    )
+
+
 def get_query_class():
     from django.conf import settings
 
@@ -191,6 +214,10 @@ class __Query__:
             sortreverse = self.params.get("sortreverse", None)
             if sortreverse:
                 sorting = f"-{sorting}"
+            if sorting.lstrip("-") == "last_followup":
+                # last_followup is an annotation, not a model field, so it must
+                # be attached to the queryset before order_by() can use it.
+                queryset = queryset.annotate(last_followup=last_followup_subquery())
             queryset = queryset.order_by(sorting)
         # https://stackoverflow.com/questions/30487056/django-queryset-contains-duplicate-entries
         return queryset.distinct()
@@ -235,23 +262,13 @@ class __Query__:
         if order == "desc":
             order_column = "-" + order_column
 
-        queryset = objects.annotate(
-            last_followup=Subquery(
-                FollowUp.objects.order_by()
-                .annotate(
-                    last_followup=Window(
-                        expression=Max("date"),
-                        partition_by=[
-                            F("ticket_id"),
-                        ],
-                        order_by="-date",
-                    )
-                )
-                .filter(ticket_id=OuterRef("id"))
-                .values("last_followup")
-                .distinct()
-            )
-        )
+        # The serializer (DatatablesTicketSerializer.get_last_followup) accesses
+        # obj.last_followup, so the annotation must always be present regardless
+        # of sorting. When sorting == "last_followup", __run__ already annotated
+        # it; Django silently overrides with the same expression, so correctness
+        # is preserved. The minor perf cost (one extra subquery in the SQL plan)
+        # is acceptable given the serializer requirement.
+        queryset = objects.annotate(last_followup=last_followup_subquery())
 
         total = queryset.count()
 

--- a/src/helpdesk/templates/helpdesk/filters/sorting.html
+++ b/src/helpdesk/templates/helpdesk/filters/sorting.html
@@ -11,8 +11,17 @@
 <div class="collapse show my-3" id="collapseSorting">
   <label id="sort-by" class="form-label" for="id_sort">{% translate "Sorting" %}</label>
   <select class="form-select" id="id_sort" name="sort">
+    <option value='id'{% if query_params.sorting == "id" %} selected='selected'{% endif %}>
+      {% translate "Ticket" %}
+    </option>
     <option value='created'{% if query_params.sorting == "created" %} selected='selected'{% endif %}>
       {% translate "Created" %}
+    </option>
+    <option value='last_followup'{% if query_params.sorting == "last_followup" %} selected='selected'{% endif %}>
+      {% translate "Last Followup" %}
+    </option>
+    <option value='due_date'{% if query_params.sorting == "due_date" %} selected='selected'{% endif %}>
+      {% translate "Due Date" %}
     </option>
     <option value='title'{% if query_params.sorting == "title" %} selected='selected'{% endif %}>
       {% translate "Title" %}
@@ -29,6 +38,14 @@
     <option value='assigned_to'{% if query_params.sorting == "assigned_to" %} selected='selected'{% endif %}>
       {% translate "Owner" %}
     </option>
+    <option value='submitter_email'{% if query_params.sorting == "submitter_email" %} selected='selected'{% endif %}>
+      {% translate "Submitter E-Mail" %}
+    </option>
+    {% if helpdesk_settings.HELPDESK_KB_ENABLED %}
+    <option value='kbitem'{% if query_params.sorting == "kbitem" %} selected='selected'{% endif %}>
+      {% translate "KB Item" %}
+    </option>
+    {% endif %}
   </select>
   <div class="form-check mt-3">
     <label class="form-check-label" for="id_sortreverse">{% translate "Reverse?" %}</label>

--- a/src/helpdesk/views/staff.py
+++ b/src/helpdesk/views/staff.py
@@ -1200,6 +1200,9 @@ def ticket_list(request: HttpRequest) -> HttpResponse:
         "priority",
         "last_followup",
         "kbitem",
+        "id",
+        "due_date",
+        "submitter_email",
     }
 
     FILTERS = {

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,8 +1,9 @@
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.urls import reverse
+from django.utils import timezone
 
-from helpdesk.models import KBCategory, KBItem, Queue, Ticket
+from helpdesk.models import FollowUp, KBCategory, KBItem, Queue, Ticket
 from helpdesk.query import query_to_base64
 
 from .helpers import get_staff_user
@@ -222,3 +223,40 @@ class QueryTests(TestCase):
             reverse("helpdesk:timeline_ticket_list", args=[query])
         )
         self.assertEqual(response.status_code, 200)
+
+    def test_query_allows_new_sorting_keys_on_timeline(self):
+        self.loginUser()
+        for sorting in ("id", "due_date", "submitter_email", "last_followup"):
+            for sortreverse in (False, True):
+                with self.subTest(sorting=sorting, sortreverse=sortreverse):
+                    query = query_to_base64(
+                        {"sorting": sorting, "sortreverse": sortreverse}
+                    )
+                    response = self.client.get(
+                        reverse("helpdesk:timeline_ticket_list", args=[query])
+                    )
+                    self.assertEqual(response.status_code, 200)
+
+    def test_query_sorts_datatables_by_last_followup(self):
+        self.loginUser()
+        FollowUp.objects.create(
+            ticket=self.ticket1,
+            date=timezone.now() - timezone.timedelta(days=2),
+        )
+        FollowUp.objects.create(
+            ticket=self.ticket2,
+            date=timezone.now() - timezone.timedelta(days=1),
+        )
+        for sortreverse, expected_order in [(False, [1, 2]), (True, [2, 1])]:
+            with self.subTest(sortreverse=sortreverse):
+                query = query_to_base64(
+                    {"sorting": "last_followup", "sortreverse": sortreverse}
+                )
+                response = self.client.get(
+                    reverse("helpdesk:datatables_ticket_list", args=[query])
+                )
+                self.assertEqual(response.status_code, 200)
+                resp_json = response.json()
+                self.assertEqual(
+                    [row["id"] for row in resp_json["data"]], expected_order
+                )

--- a/tests/test_staff_ticket_list_view.py
+++ b/tests/test_staff_ticket_list_view.py
@@ -87,6 +87,36 @@ class StaffTicketListViewTests(TestCase):
         # Check default query params are loaded
         self.assertEqual(r.context["query_params"], self.default_params)
 
+    def test_sorting_dropdown_lists_all_sortable_columns(self):
+        self.client.force_login(self.staff_user)
+        r = self.client.get(self.url)
+        self.assertEqual(r.status_code, HTTPStatus.OK)
+        for sort_value in (
+            "id",
+            "created",
+            "last_followup",
+            "due_date",
+            "title",
+            "queue",
+            "status",
+            "priority",
+            "assigned_to",
+            "submitter_email",
+            "kbitem",
+        ):
+            self.assertContains(r, f"value='{sort_value}'")
+
+    def test_sort_last_followup_is_accepted_and_selected(self):
+        self.client.force_login(self.staff_user)
+        r = self.client.get(self.url, data={"sort": "last_followup"})
+        self.assertEqual(r.status_code, HTTPStatus.OK)
+        self.assertEqual(r.context["query_params"]["sorting"], "last_followup")
+        self.assertContains(
+            r,
+            "<option value='last_followup' selected='selected'>",
+            html=False,
+        )
+
     def test_user_saved_queries_executed_correctly(self):
         # Arrange: We create a public saved query for the user
         query = query_to_base64(self.default_params)
@@ -132,3 +162,12 @@ class StaffTicketListViewTests(TestCase):
             r = self.client.get(self.url)
             self.assertEqual(r.context["kb_items"], [])
             self.assertEqual(r.context["kbitem_choices"], [])
+
+    def test_sorting_dropdown_hides_kbitem_when_kb_disabled(self):
+        KB_SETTINGS_PATH = "helpdesk.views.staff.helpdesk_settings.HELPDESK_KB_ENABLED"
+        self.client.force_login(self.staff_user)
+
+        with patch(KB_SETTINGS_PATH, new=False):
+            r = self.client.get(self.url)
+            self.assertEqual(r.status_code, HTTPStatus.OK)
+            self.assertNotContains(r, "value='kbitem'")


### PR DESCRIPTION
Add id, last_followup, due_date, submitter_email and kbitem to the Sorting dropdown in the /tickets/ filters, matching the columns already supported by ALLOWED_SORTS and DATATABLES_ORDER_COLUMN_CHOICES.

last_followup is an annotation rather than a model field, so ordering by it previously raised a FieldError on both the datatables and timeline endpoints. Extract the followup Subquery into a reusable helper and annotate the queryset before order_by() in __run__().

(issue #1369)