### PR TITLE
Drop four unused dependency declarations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,15 +25,12 @@ dependencies = [
     "akismet",
     "markdown",
     "beautifulsoup4",
-    "pytz",
     "djangorestframework",
     "django-model-utils",
     "django-cleanup",
     "oauthlib",
     "requests-oauthlib",
     "requests",
-    "requests_oauthlib",
-    "setuptools",
 ]
 
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ dependencies = [
     "akismet",
     "markdown",
     "beautifulsoup4",
-    "lxml",
     "pytz",
     "djangorestframework",
     "django-model-utils",

--- a/standalone/requirements.txt
+++ b/standalone/requirements.txt
@@ -9,7 +9,6 @@ email-reply-parser
 akismet
 markdown
 beautifulsoup4
-lxml
 pytz
 pinax_teams
 djangorestframework

--- a/standalone/requirements.txt
+++ b/standalone/requirements.txt
@@ -9,7 +9,6 @@ email-reply-parser
 akismet
 markdown
 beautifulsoup4
-pytz
 pinax_teams
 djangorestframework
 django-model-utils


### PR DESCRIPTION
> [!NOTE]
> The earlier red runs on this branch were unrelated to its contents: `djangorestframework` 3.18.0 requires `django>=5.2`, and the workflow used to layer `--with django~=${matrix}` over an environment resolved against the newest Django. Any pull request touching `pyproject.toml` invalidated the dependency cache and hit it. Fixed by #1373, and this branch has been rebased on top of it. Green now.

Four entries in `dependencies` that nothing in the project uses. Each was verified by grepping for the real import name rather than the package name, since several of them differ.

### `lxml`

Added in 65c1d05e (2017) as the parser backend for BeautifulSoup, to pull text out of HTML-only emails. Commit 344dd75a (February 2019, first released in 0.3.0b1) switched that call to `BeautifulSoup(str(message), "html.parser")`, the standard library parser, and the dependency was never removed. Nothing has imported it since, directly or as a BeautifulSoup backend, and no other declared dependency requires it. So every install has been building or fetching a compiled C extension it never loads, for about seven years.

### `pytz`

Imported nowhere. `USE_DEPRECATED_PYTZ` is set nowhere either, and the project requires Django 4.2+, which uses `zoneinfo`. Django 5.0 removed pytz support entirely.

### `setuptools`

Imported nowhere, and neither is `pkg_resources`. The build backend is `pdm-backend`, so it is not needed to build the package either. It stays present in the test environment because `pbr` pulls it in.

### `requests_oauthlib`

Declared twice, once under each spelling: `requests-oauthlib` and `requests_oauthlib`. PEP 503 normalises `-` and `_` to the same name, so both entries always resolved to the single `requests-oauthlib` distribution. `uv pip show` only ever saw one package.

### Verification

Removed from `pyproject.toml` and, where present, from `standalone/requirements.txt`. The environment was then re-synced so that `lxml` and `pytz` were genuinely uninstalled, not merely undeclared, and confirmed absent with `importlib.util.find_spec`. The full test suite passes: 224 tests, 2 skipped.

### Downstream note

If you were relying on django-helpdesk to pull `lxml` or `pytz` into your environment for your own code, declare them yourself.


