### PR TITLE
ci: resolve Django with its dependents instead of layering it on

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,15 @@ jobs:
     
       - name: Run tests
         run: |
-          cd ${GITHUB_WORKSPACE} && uv run --with django~=${{ matrix.django-version }} coverage run quicktest.py
+          # Resolve Django together with the packages that constrain it, rather
+          # than layering `--with django~=X` over an environment that was
+          # resolved against the newest Django. That layering silently produces
+          # combinations the resolver would reject: DRF 3.18 requires Django
+          # >= 5.2, so the 4.2 leg ended up running DRF 3.18 against Django 4.2
+          # and failing at runtime instead of at resolution time.
+          # `uv run --no-sync` is required, otherwise it re-syncs and undoes this.
+          uv pip install "django~=${{ matrix.django-version }}" djangorestframework
+          cd ${GITHUB_WORKSPACE} && uv run --no-sync coverage run quicktest.py
         env:
           DJANGO_SETTINGS_MODULE: helpdesk.settings
 


### PR DESCRIPTION
## The failure

Any pull request touching `pyproject.toml` currently turns red on the Django 4.2, 5.0 and 5.1 legs, with a traceback that points nowhere useful:

```
File ".../rest_framework/fields.py", line 547, in run_validators
    validator(value)
TypeError: 'list' object is not callable
```

`main` is green only by accident, and will not stay that way.

## The cause

`djangorestframework` 3.18.0 was released recently and requires `django>=5.2`.

The test step layers `--with django~=${{ matrix.django-version }}` over an environment that `make sync` has already resolved against the newest Django. `--with` does not re-resolve what is already installed, so on the older legs the job installs DRF 3.18 during `make sync`, then downgrades Django underneath it. DRF then runs against a Django it does not support, and fails deep inside field validation with a message that gives no hint the real problem is an impossible dependency pair.

Asking the resolver for that pair directly makes it say so plainly:

```
Because djangorestframework==3.18.0 depends on django>=5.2 and you
require django>=4.2,<5.dev0, we can conclude that your requirements and
djangorestframework==3.18.0 are incompatible.
```

The reason this only started now is the cache. It is keyed on `hashFiles('pyproject.toml')`, so `main` keeps reusing a resolution that predates DRF 3.18, while any pull request that edits that file gets a fresh one. The contents of the edit are irrelevant.

## The fix

Resolve Django together with what constrains it, rather than layering it on afterwards:

```yaml
uv pip install "django~=${{ matrix.django-version }}" djangorestframework
cd ${GITHUB_WORKSPACE} && uv run --no-sync coverage run quicktest.py
```

An unsupportable combination now fails at resolution time with a clear message, instead of at runtime with a confusing traceback. `--no-sync` is required: without it `uv run` re-syncs and immediately undoes the pin.

## Verification

Checked locally on Python 3.10 with Django 4.2 across DRF 3.15.2, 3.16.0, 3.16.1, 3.17.0 and 3.17.1: the full suite passes, 224 tests, 2 skipped. Only DRF 3.18 paired with a Django older than 5.2 fails. With this change the joint resolution yields Django 4.2.30 with DRF 3.17.1, and the suite passes.

## Known limitation

Only Django and DRF are re-resolved together. If another dependency comes to constrain Django, it will need adding to that line. The general answer is a committed lock file, which is a larger discussion: a single lock cannot serve a matrix of four Django versions, since `uv.lock` keys alternative resolutions on environment markers such as `python_full_version`, not on matrix legs. Worth doing for contributor reproducibility, but it would not replace this change.
