### PR TITLE
chore: make celery and akismet optional extras

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -19,7 +19,7 @@ Before django-helpdesk will be much use, you need to do some basic configuration
 
    You will need to create a support queue, and associated login/host values, in the Django admin interface, in order for mail to be picked-up from the mail server and placed in the tickets table of your database. The values in the settings file alone, will not create the necessary values to trigger the get_email function.
 
- If you wish to use `celery` instead of cron, you must add 'django_celery_beat' to `INSTALLED_APPS` and add a periodic celery task through the Django admin.
+ If you wish to use `celery` instead of cron, install the optional dependencies with ``pip install django-helpdesk[celery]``, add 'django_celery_beat' to `INSTALLED_APPS`, and add a periodic celery task through the Django admin pointing at ``helpdesk.tasks.helpdesk_process_email``.
 
    You will need to create a support queue, and associated login/host values, in the Django admin interface, in order for mail to be picked-up from the mail server and placed in the tickets table of your database. The values in the settings file alone, will not create the necessary values to trigger the get_email function.
    

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -76,7 +76,7 @@ errors with trying to create User settings.
             'django.contrib.humanize',  # Required for elapsed time formatting
             'bootstrap4form', # Required for nicer formatting of forms with the default templates
             'rest_framework',  # required for the API
-            'django_cleanup.apps.CleanupConfig',  # Optional, needs `pip install django-helpdesk[cleanup]`. Remove this if you do NOT want to delete files on the file system when the associated record is deleted in the database
+            'django_cleanup.apps.CleanupConfig',  # Remove this if you do NOT want to delete files on the file system when the associated record is deleted in the database
             'helpdesk',  # This is us!
         )
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -76,7 +76,7 @@ errors with trying to create User settings.
             'django.contrib.humanize',  # Required for elapsed time formatting
             'bootstrap4form', # Required for nicer formatting of forms with the default templates
             'rest_framework',  # required for the API
-            'django_cleanup.apps.CleanupConfig',  # Remove this if you do NOT want to delete files on the file system when the associated record is deleted in the database
+            'django_cleanup.apps.CleanupConfig',  # Optional, needs `pip install django-helpdesk[cleanup]`. Remove this if you do NOT want to delete files on the file system when the associated record is deleted in the database
             'helpdesk',  # This is us!
         )
 

--- a/docs/spam.rst
+++ b/docs/spam.rst
@@ -3,7 +3,7 @@ Spam Filtering
 
 django-helpdesk includes a copy of ``akismet.py`` by `Michael Foord <http://www.voidspace.org.uk/>`_, which lets incoming ticket submissions be automatically checked against either the `Akismet <http://akismet.com/>`_ or `TypePad Anti-Spam <http://antispam.typepad.com/>`_ services.
 
-To enable this functionality, sign up for an API key with one of these two services.
+To enable this functionality, install the optional dependency with ``pip install django-helpdesk[spam]`` and sign up for an API key with one of these two services. Without that dependency installed, submissions are simply never flagged as spam.
 
 Akismet
 ~~~~~~~

--- a/docs/upgrade.rst
+++ b/docs/upgrade.rst
@@ -10,6 +10,38 @@ Please consult the Installation instructions for general instructions and tips.
 The tips below are based on modifications of the original installation instructions.
 
 
+Optional integrations are no longer installed by default
+--------------------------------------------------------
+
+Three packages used to be installed with every copy of django-helpdesk even
+though the project itself never imports them, and none of them are needed for a
+default install. They are now optional extras:
+
+===================  ========================================  ==================================
+Feature              Install with                              Needed if you
+===================  ========================================  ==================================
+Celery mail polling  ``pip install django-helpdesk[celery]``   schedule ``helpdesk.tasks``
+                                                               instead of running ``get_email``
+                                                               from cron
+Akismet spam check   ``pip install django-helpdesk[spam]``     set ``AKISMET_API_KEY`` or
+                                                               ``TYPEPAD_ANTISPAM_API_KEY``
+File cleanup         ``pip install django-helpdesk[cleanup]``  list
+                                                               ``django_cleanup.apps.CleanupConfig``
+                                                               in ``INSTALLED_APPS``
+===================  ========================================  ==================================
+
+If you would rather not work out which apply to you, ``pip install
+django-helpdesk[all]`` restores exactly what earlier releases pulled in.
+
+The Celery extra also brings ``django-celery-beat``, which that setup has always
+required but which was never declared.
+
+Nothing breaks silently except the Akismet case: ``text_is_spam()`` already
+treated a missing Akismet package as "not spam", so an upgrade without the extra
+means submissions stop being checked rather than raising an error. The other two
+fail loudly, at import or at startup.
+
+
 0.2 -> 0.3
 ----------
 

--- a/docs/upgrade.rst
+++ b/docs/upgrade.rst
@@ -13,22 +13,19 @@ The tips below are based on modifications of the original installation instructi
 Optional integrations are no longer installed by default
 --------------------------------------------------------
 
-Three packages used to be installed with every copy of django-helpdesk even
-though the project itself never imports them, and none of them are needed for a
-default install. They are now optional extras:
+Two packages used to be installed with every copy of django-helpdesk even though
+the project itself never imports them, and neither is needed for a default
+install. They are now optional extras:
 
-===================  ========================================  ==================================
-Feature              Install with                              Needed if you
-===================  ========================================  ==================================
-Celery mail polling  ``pip install django-helpdesk[celery]``   schedule ``helpdesk.tasks``
-                                                               instead of running ``get_email``
-                                                               from cron
-Akismet spam check   ``pip install django-helpdesk[spam]``     set ``AKISMET_API_KEY`` or
-                                                               ``TYPEPAD_ANTISPAM_API_KEY``
-File cleanup         ``pip install django-helpdesk[cleanup]``  list
-                                                               ``django_cleanup.apps.CleanupConfig``
-                                                               in ``INSTALLED_APPS``
-===================  ========================================  ==================================
+===================  ======================================  ==================================
+Feature              Install with                            Needed if you
+===================  ======================================  ==================================
+Celery mail polling  ``pip install django-helpdesk[celery]``  schedule ``helpdesk.tasks``
+                                                             instead of running ``get_email``
+                                                             from cron
+Akismet spam check   ``pip install django-helpdesk[spam]``    set ``AKISMET_API_KEY`` or
+                                                             ``TYPEPAD_ANTISPAM_API_KEY``
+===================  ======================================  ==================================
 
 If you would rather not work out which apply to you, ``pip install
 django-helpdesk[all]`` restores exactly what earlier releases pulled in.
@@ -36,10 +33,16 @@ django-helpdesk[all]`` restores exactly what earlier releases pulled in.
 The Celery extra also brings ``django-celery-beat``, which that setup has always
 required but which was never declared.
 
-Nothing breaks silently except the Akismet case: ``text_is_spam()`` already
-treated a missing Akismet package as "not spam", so an upgrade without the extra
-means submissions stop being checked rather than raising an error. The other two
-fail loudly, at import or at startup.
+Neither of these breaks a running site on its own. ``helpdesk/urls.py`` already
+imports ``helpdesk.tasks`` inside a ``try/except ImportError``, and
+``text_is_spam()`` already treated a missing Akismet package as "not spam", so
+an upgrade without the extras means the scheduled task is not registered and
+submissions stop being spam checked, rather than anything raising.
+
+``django-cleanup`` is deliberately not on this list. It activates as soon as it
+is listed in ``INSTALLED_APPS``, which is what our own installation
+instructions suggest, so making it optional would stop a documented
+configuration from starting at all. It stays a hard dependency.
 
 
 0.2 -> 0.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,14 +20,16 @@ packages = [
 dependencies = [
     "django>=4.2",
     "django-bootstrap4-form",
-    "celery",
+    # django-bootstrap4-form imports `packaging` in its meta.py but only
+    # declares `django`, so it cannot load without this. Until then it reached
+    # us transitively through celery's dependency chain, which stopped being
+    # installed by default here. Declared explicitly rather than left to luck.
+    "packaging",
     "email-reply-parser",
-    "akismet",
     "markdown",
     "beautifulsoup4",
     "djangorestframework",
     "django-model-utils",
-    "django-cleanup",
     "oauthlib",
     "requests-oauthlib",
     "requests",
@@ -58,6 +60,28 @@ classifiers = [
 [project.optional-dependencies]
 teams = [
     "pinax_teams",
+]
+# Poll mailboxes with a periodic celery task instead of cron. See
+# docs/configuration.rst. django-celery-beat is what actually schedules it, and
+# was previously left to the operator to work out.
+celery = [
+    "celery",
+    "django-celery-beat",
+]
+# Check incoming ticket submissions against Akismet. See docs/spam.rst.
+# helpdesk.lib.text_is_spam already degrades to "not spam" when this is absent.
+spam = [
+    "akismet",
+]
+# Delete files from storage when the record referencing them is deleted. See
+# docs/install.rst.
+cleanup = [
+    "django-cleanup",
+]
+# Everything above, for anyone who wants what earlier releases installed by
+# default.
+all = [
+    "django-helpdesk[celery,spam,cleanup,teams]",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,10 @@ packages = [
 dependencies = [
     "django>=4.2",
     "django-bootstrap4-form",
+    # Kept as a hard dependency on purpose: it activates automatically when listed
+    # in INSTALLED_APPS, as docs/install.rst suggests, so a copy that follows our
+    # own instructions would refuse to start without it.
+    "django-cleanup",
     # django-bootstrap4-form imports `packaging` in its meta.py but only
     # declares `django`, so it cannot load without this. Until then it reached
     # us transitively through celery's dependency chain, which stopped being
@@ -73,15 +77,10 @@ celery = [
 spam = [
     "akismet",
 ]
-# Delete files from storage when the record referencing them is deleted. See
-# docs/install.rst.
-cleanup = [
-    "django-cleanup",
-]
 # Everything above, for anyone who wants what earlier releases installed by
 # default.
 all = [
-    "django-helpdesk[celery,spam,cleanup,teams]",
+    "django-helpdesk[celery,spam,teams]",
 ]
 
 [dependency-groups]

--- a/src/helpdesk/urls.py
+++ b/src/helpdesk/urls.py
@@ -27,8 +27,11 @@ from helpdesk.views.api import (
 if helpdesk_settings.HELPDESK_KB_ENABLED:
     from helpdesk.views import kb
 
+# Importing the module is the side effect: that is what registers the
+# @shared_task it defines, for projects that do not rely on Celery's own
+# autodiscover_tasks(). Celery is an optional extra, so its absence is not an
+# error, there is simply no task to register.
 try:
-    # TODO: why is it imported? due to some side-effect or by mistake?
     import helpdesk.tasks  # NOQA
 except ImportError:
     pass

--- a/standalone/requirements.txt
+++ b/standalone/requirements.txt
@@ -10,6 +10,7 @@ beautifulsoup4
 pinax_teams
 djangorestframework
 django-model-utils
+django-cleanup
 oauthlib
 requests_oauthlib
 requests

--- a/standalone/requirements.txt
+++ b/standalone/requirements.txt
@@ -4,15 +4,12 @@ psycopg2-binary
 django
 
 django-bootstrap4-form
-celery
 email-reply-parser
-akismet
 markdown
 beautifulsoup4
 pinax_teams
 djangorestframework
 django-model-utils
-django-cleanup
 oauthlib
 requests_oauthlib
 requests


### PR DESCRIPTION
Opened as a draft to agree on the principle before anyone reviews it line by line. Follow-up to #1372, which removed four dependencies nothing used at all. These are different: they are used, just not by a default install.

> [!NOTE]
> Updated after @uhurusurfa's review: `django-cleanup` stays a hard dependency. See "Why django-cleanup is not in this list" below.

## What changes

`celery` and `akismet` move from `dependencies` to `[project.optional-dependencies]`.

| Feature | Install with | Needed if you |
|---|---|---|
| Celery mail polling | `pip install django-helpdesk[celery]` | schedule `helpdesk.tasks` instead of running `get_email` from cron |
| Akismet spam check | `pip install django-helpdesk[spam]` | set `AKISMET_API_KEY` or `TYPEPAD_ANTISPAM_API_KEY` |

`pip install django-helpdesk[all]` restores exactly what earlier releases pulled in.

## Why each one

**`celery`** is only used by `src/helpdesk/tasks.py`, a seven-line module imported from exactly one place: `helpdesk/urls.py`, inside a `try/except ImportError` that has been there for years. The extra also brings `django-celery-beat`, which `docs/configuration.rst` has always instructed operators to add to `INSTALLED_APPS` but which was never declared anywhere.

**`akismet`** is imported lazily inside `text_is_spam()`, already wrapped in `try/except ImportError` returning "not spam".

Neither can stop a site from starting. The code has treated both as optional for years; only the packaging disagreed.

## Why django-cleanup is not in this list

It was in the first version of this branch and has been reverted. Unlike the other two, `django-cleanup` activates as soon as it is listed in `INSTALLED_APPS`, which is exactly what `docs/install.rst` tells people to do. Making it optional would stop a documented configuration from booting, which is a different class of breakage. It also buys the least: it pulls nothing else in, where celery alone accounts for most of the reduction below.

## A latent bug this surfaced

Dropping `celery` broke Django app loading, which turned out to have nothing to do with celery. `django-bootstrap4-form` imports `packaging` in its `meta.py` while declaring only `django`, so it cannot load without it. It had been arriving transitively through `kombu`, a celery dependency. An unused dependency was masking a missing one. This branch declares `packaging` explicitly; the upstream project is worth an issue as well, though it has released twice in eight years so it is not a fix to wait on.

## Impact

About twenty packages disappear from a default install, celery pulling `amqp`, `billiard`, `kombu`, `vine` and others. Full suite passes with both absent: 224 tests, 2 skipped.

Only one thing degrades silently: without `[spam]`, `text_is_spam()` already returned "not spam" for a missing package, so submissions stop being checked rather than raising. `docs/upgrade.rst` says so explicitly, and also records why `django-cleanup` is deliberately not optional, so this does not get proposed again in six months.

## About the coverage drop

Coveralls reports -0.02% overall, entirely from `src/helpdesk/tasks.py` falling from 80% to 20%. That is the honest number rather than a regression: the module has five statements, four of which used to run simply because the module was imported. Without celery installed, line 1 raises `ImportError` and the rest is never reached.

What imported it is `helpdesk/urls.py`, and it was already written to tolerate celery's absence:

```python
try:
    # TODO: why is it imported? due to some side-effect or by mistake?
    import helpdesk.tasks  # NOQA
except ImportError:
    pass
```

The second commit answers that TODO. The import is there for its side effect, registering the `@shared_task` for projects that do not use Celery's `autodiscover_tasks()`, and the `try/except` is now documented behaviour rather than a defensive accident.

Adding `tasks.py` to `omit` in `.coveragerc` would hide the number instead of reporting it, so I have not. The principled answer would be a CI leg installing `django-helpdesk[all]` so the optional paths stay exercised, which seems worth doing but as its own change rather than smuggled in here.

## This is still a breaking change

Anyone who relies on django-helpdesk to pull celery or akismet in without declaring them will need the relevant extra. That rules out a 2.3.x patch release; this should target 2.4.

## Open questions

1. Are `celery` and `spam` the right extra names? They are feature-named for consistency with the existing `teams` extra, rather than package-named.
2. Is `[all]` a good migration aid, or does it just encourage people not to think about it?
3. Should the standalone image keep `akismet` so spam filtering stays available there out of the box? Its Dockerfile polls mail with cron, so it has no use for celery either way.

Docs updated: `install.rst`, `configuration.rst`, `spam.rst`, and a new section in `upgrade.rst`.
