### PR TITLE
docs: write down how we handle a security report

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,3 +15,53 @@ Once reported, we'll be in touch to confirm the issue and work toward releasing 
 After a patch has been released, a new release will be tagged and uploaded to PyPi, etc. At that time, details of the issue will be announced publicly.
 
 Users are always highly encouraged to upgrade to the latest bugfix release as soon as possible.
+
+## Handling a report
+
+This section is for maintainers. It exists because the substance of a fix is the
+easy part: what goes wrong is the sequencing, and it goes wrong when no single
+person is holding the whole chain.
+
+**Assign an owner as soon as a report arrives.** One named maintainer, responsible
+from intake through to publication. Everything below is theirs to drive, not to
+delegate and hope.
+
+1. **Open a draft security advisory early**, under Security > Advisories. Credit
+   the reporter and add them as a collaborator on the advisory so they can review
+   the description and the severity. They usually know the issue better than we
+   do, and they will catch an inaccurate write-up before it is public.
+
+2. **Request the CVE at draft stage**, not at the end. GitHub quotes up to three
+   working days to review the request, and requesting it discloses nothing, so it
+   may as well run in parallel with the fix. Publishing before the identifier is
+   assigned is fine: it gets attached to the advisory when their review completes.
+
+3. **Fill in the affected version range honestly.** Work out when the vulnerable
+   code was actually introduced rather than assuming it was recent, and make the
+   upper bound match the version that will carry the fix. A range that disagrees
+   with the patched version tells Dependabot that people already on the previous
+   release are safe when they are not.
+
+4. **Build the fix in the advisory's temporary private fork**, reviewed by a
+   second maintainer. Put the version bump in the same pull request as the fix,
+   so no separate bump pull request is needed afterwards. Add regression tests
+   that fail without the fix.
+
+5. **Merge, tag, and confirm the release is live on PyPI, in that order and
+   without pausing.** Merging is what makes the vulnerability public, because the
+   commit and its message describe it. From that moment until the release is
+   installable, the issue is disclosed with no fix available. That window should
+   be minutes.
+
+6. **Chase credit acceptance before publishing.** Credits that have not been
+   accepted never appear in the published advisory, and the record ends up
+   showing fewer people than were actually involved.
+
+7. **Publish the advisory last**, once the version it names can actually be
+   installed.
+
+Steps 5 and 7 are the ones worth re-reading. Publishing an advisory that points
+at a version nobody can install is worse than publishing a day later.
+
+If the fix turns out to be incomplete after release, treat the follow-up as its
+own pass through this list rather than amending the published advisory in place.


### PR DESCRIPTION
Per @uhurusurfa's suggestion by email, and his agreement on the shape.

`SECURITY.md` covered how a reporter contacts us and stopped there. Everything after that point was improvised, and the last two advisories showed what that costs:

- **GHSA-mxcg-7m22-x9pj** needed a second release, because the first patch was incomplete and 2.3.1 was declared as fixed while a variant of the same bug was still exploitable.
- **GHSA-q46c-8w98-fq2g** was published a full day before 2.3.3 existed on PyPI. The issue was fully disclosed, the fix was not installable, and Dependabot was pointing people at a version that did not exist.

Neither was any individual's mistake, which is exactly the point: nobody was holding the whole chain. So the new section starts by assigning an owner at intake, then lists seven steps in the order that keeps the disclosure window short.

The two that matter most are 5 and 7: merging is what makes a vulnerability public, since the commit and its message describe it, so the gap between merge and an installable release should be minutes, and the advisory should be published last.

Nothing here is new policy, it is what we ended up doing once we had learned it the hard way. Written down so the next person does not have to.

## Suggestion for separately

Private vulnerability reporting is currently **disabled** on this repository:

```
GET /repos/django-helpdesk/django-helpdesk/private-vulnerability-reporting
{"enabled": false}
```

Enabling it would let reporters open a draft advisory directly from the Security tab rather than emailing a personal address, which is how both recent reports arrived. It creates the draft for us, so steps 1 and 3 above start from a better place, and it removes the single point of contact. It is a repository setting rather than a file change, so I have not touched `SECURITY.md` for it. Worth a separate decision.
