### PR TITLE
feat: render forms with our own Bootstrap 5 templates

### DIFF
--- a/demodesk/config/settings.py
+++ b/demodesk/config/settings.py
@@ -47,7 +47,6 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "django.contrib.sites",
     "django.contrib.humanize",
-    "bootstrap4form",
     "helpdesk",  # This is us!
     "rest_framework",  # required for the API
 ]

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -74,7 +74,6 @@ errors with trying to create User settings.
             'django.contrib.sites',  # Required for determining domain url for use in emails
             'django.contrib.admin',  # Required for helpdesk admin/maintenance
             'django.contrib.humanize',  # Required for elapsed time formatting
-            'bootstrap4form', # Required for nicer formatting of forms with the default templates
             'rest_framework',  # required for the API
             'django_cleanup.apps.CleanupConfig',  # Remove this if you do NOT want to delete files on the file system when the associated record is deleted in the database
             'helpdesk',  # This is us!

--- a/docs/upgrade.rst
+++ b/docs/upgrade.rst
@@ -10,6 +10,26 @@ Please consult the Installation instructions for general instructions and tips.
 The tips below are based on modifications of the original installation instructions.
 
 
+Form rendering no longer needs django-bootstrap4-form
+-----------------------------------------------------
+
+``django-bootstrap4-form`` has been removed. It emitted Bootstrap 3 markup
+(``form-group``, ``control-label``, ``has-error``, ``<div class="checkbox">``),
+none of which exists in the Bootstrap 5 stylesheet this project ships, so the
+affected fields had lost their spacing and their checkboxes and radios were
+unstyled. Forms are now rendered by a template inside django-helpdesk itself.
+
+Remove ``'bootstrap4form'`` from your ``INSTALLED_APPS``. Nothing else is
+required, and the package can be uninstalled unless something else in your
+project uses it.
+
+If you have overridden ``user_settings.html``, ``edit_ticket.html`` or
+``public_create_ticket_base.html``, replace ``{{ form|bootstrap4form }}`` with::
+
+    {% load bootstrap5_form %}
+    {% bootstrap5_form form %}
+
+
 Optional integrations are no longer installed by default
 --------------------------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,16 +19,10 @@ packages = [
 ]
 dependencies = [
     "django>=4.2",
-    "django-bootstrap4-form",
     # Kept as a hard dependency on purpose: it activates automatically when listed
     # in INSTALLED_APPS, as docs/install.rst suggests, so a copy that follows our
     # own instructions would refuse to start without it.
     "django-cleanup",
-    # django-bootstrap4-form imports `packaging` in its meta.py but only
-    # declares `django`, so it cannot load without this. Until then it reached
-    # us transitively through celery's dependency chain, which stopped being
-    # installed by default here. Declared explicitly rather than left to luck.
-    "packaging",
     "email-reply-parser",
     "markdown",
     "beautifulsoup4",

--- a/quicktest.py
+++ b/quicktest.py
@@ -40,7 +40,6 @@ class QuickDjangoTest:
         "django.contrib.sessions",
         "django.contrib.sites",
         "django.contrib.staticfiles",
-        "bootstrap4form",
         #  The following commented apps are optional,
         #  related to teams functionalities
         # 'account',

--- a/src/helpdesk/forms.py
+++ b/src/helpdesk/forms.py
@@ -82,7 +82,7 @@ class CustomFieldMixin:
         elif field.data_type == "list":
             fieldclass = forms.ChoiceField
             instanceargs["choices"] = field.get_choices()
-            instanceargs["widget"] = forms.Select(attrs={"class": "form-control"})
+            instanceargs["widget"] = forms.Select(attrs={"class": "form-select"})
         else:
             # Try to use the immediate equivalences dictionary
             try:
@@ -102,7 +102,7 @@ class CustomFieldMixin:
                     )
                 elif fieldclass == forms.BooleanField:
                     instanceargs["widget"] = forms.CheckboxInput(
-                        attrs={"class": "form-control"}
+                        attrs={"class": "form-check-input"}
                     )
 
             except KeyError:

--- a/src/helpdesk/templates/helpdesk/create_ticket.html
+++ b/src/helpdesk/templates/helpdesk/create_ticket.html
@@ -1,4 +1,4 @@
-{% extends "helpdesk/base.html" %}{% load i18n bootstrap4form %}
+{% extends "helpdesk/base.html" %}{% load i18n %}
 
 {% block helpdesk_title %}{% trans "Create Ticket" %}{% endblock %}
 

--- a/src/helpdesk/templates/helpdesk/edit_ticket.html
+++ b/src/helpdesk/templates/helpdesk/edit_ticket.html
@@ -1,6 +1,6 @@
 {% extends "helpdesk/base.html" %}
 
-{% load i18n bootstrap4form %}
+{% load i18n bootstrap5_form %}
 
 {% block helpdesk_title %}{% trans "Edit Ticket" %}{% endblock %}
 
@@ -30,7 +30,7 @@
                 <form method='post'>
                     {% csrf_token %}
                     <fieldset>
-                        {{ form|bootstrap4form }}
+                        {% bootstrap5_form form %}
                         <div class='buttons mb-3'>
                             <input type='submit' class="btn btn-primary btn-sm" value='{% trans "Save Changes" %}'/>
                             <a href='{{ ticket.get_absolute_url }}'>

--- a/src/helpdesk/templates/helpdesk/include/form.html
+++ b/src/helpdesk/templates/helpdesk/include/form.html
@@ -1,0 +1,15 @@
+{% load bootstrap5_form %}
+{% if form.non_field_errors %}
+  <div class="alert alert-danger alert-dismissible fade show" role="alert">
+    {% for non_field_error in form.non_field_errors %}
+      <div>{{ non_field_error }}</div>
+    {% endfor %}
+    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+  </div>
+{% endif %}
+
+{% for field in form.hidden_fields %}{{ field }}{% endfor %}
+
+{% for field in form.visible_fields %}
+  {% include "helpdesk/include/form_field.html" %}
+{% endfor %}

--- a/src/helpdesk/templates/helpdesk/include/form_field.html
+++ b/src/helpdesk/templates/helpdesk/include/form_field.html
@@ -1,0 +1,38 @@
+{% load bootstrap5_form %}
+{% comment %}
+  One form field, in Bootstrap 5 markup. Widget classes are set in Python by
+  bootstrap5_form.apply_classes, so this template only lays fields out.
+
+  Errors use `invalid-feedback d-block` rather than plain `invalid-feedback`,
+  because the latter is only revealed by a sibling `.is-invalid` and that
+  relationship does not hold for the choice groups below.
+{% endcomment %}
+{% if field|is_checkbox %}
+  <div class="mb-3 form-check">
+    {{ field }}
+    <label class="form-check-label" for="{{ field.id_for_label }}">{{ field.label }}</label>
+    {% for error in field.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
+    {% if field.help_text %}<div class="form-text">{{ field.help_text|safe }}</div>{% endif %}
+  </div>
+{% elif field|is_choice_group %}
+  <fieldset class="mb-3">
+    <legend class="form-label {% if field.field.required %}{{ form.required_css_class }}{% endif %}">{{ field.label }}</legend>
+    {% for choice in field %}
+      <div class="form-check">
+        {{ choice.tag }}
+        <label class="form-check-label" for="{{ choice.id_for_label }}">{{ choice.choice_label }}</label>
+      </div>
+    {% endfor %}
+    {% for error in field.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
+    {% if field.help_text %}<div class="form-text">{{ field.help_text|safe }}</div>{% endif %}
+  </fieldset>
+{% else %}
+  <div class="mb-3">
+    {% if field.auto_id %}
+      <label class="form-label {% if field.field.required %}{{ form.required_css_class }}{% endif %}" for="{{ field.auto_id }}">{{ field.label }}</label>
+    {% endif %}
+    {{ field }}
+    {% for error in field.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
+    {% if field.help_text %}<div class="form-text">{{ field.help_text|safe }}</div>{% endif %}
+  </div>
+{% endif %}

--- a/src/helpdesk/templates/helpdesk/public_create_ticket_base.html
+++ b/src/helpdesk/templates/helpdesk/public_create_ticket_base.html
@@ -1,4 +1,4 @@
-{% load i18n bootstrap4form %}
+{% load i18n bootstrap5_form %}
 {% load load_helpdesk_settings %}
 
 {% with request|load_helpdesk_settings as helpdesk_settings %}
@@ -13,7 +13,7 @@
         {% endif %}
         <form role="form" method='post' enctype='multipart/form-data'>
             {% csrf_token %}
-            {{ form|bootstrap4form }}
+            {% bootstrap5_form form %}
             <button type="submit" class="btn btn-primary btn-lg btn-block">
                 {% trans "Submit Ticket" %} <i class="fa fa-paper-plane"></i>
             </button>

--- a/src/helpdesk/templates/helpdesk/public_homepage.html
+++ b/src/helpdesk/templates/helpdesk/public_homepage.html
@@ -1,5 +1,5 @@
 {% extends "helpdesk/public_base.html" %}
-{% load i18n bootstrap4form %}
+{% load i18n %}
 
 {% block helpdesk_title %}{% trans "Welcome to Helpdesk" %}{% endblock %}
 

--- a/src/helpdesk/templates/helpdesk/registration/login.html
+++ b/src/helpdesk/templates/helpdesk/registration/login.html
@@ -1,4 +1,4 @@
-{% extends "helpdesk/public_base.html" %}{% load i18n bootstrap4form %}
+{% extends "helpdesk/public_base.html" %}{% load i18n %}
 {% block helpdesk_title %}{% trans "Helpdesk Login" %}{% endblock %}
 
 {% block helpdesk_body %}

--- a/src/helpdesk/templates/helpdesk/ticket.html
+++ b/src/helpdesk/templates/helpdesk/ticket.html
@@ -1,5 +1,5 @@
 {% extends "helpdesk/base.html" %}
-{% load static i18n bootstrap4form humanize %}
+{% load static i18n humanize %}
 
 {% block helpdesk_title %}
   {{ ticket.queue.slug }}-{{ ticket.id }}: {% translate "View Ticket Details" %}

--- a/src/helpdesk/templates/helpdesk/user_settings.html
+++ b/src/helpdesk/templates/helpdesk/user_settings.html
@@ -20,8 +20,8 @@
 <form role="form" method='post' action='./'>
     {% csrf_token %}
     {% bootstrap5_form form %}
-    <div class="mb-3">
-      <input type="submit" value="Submit"/>
+    <div class="buttons mb-3">
+      <input type="submit" class="btn btn-primary btn-sm" value='{% trans "Save Changes" %}'/>
     </div>
 </form>
 {% endblock %}

--- a/src/helpdesk/templates/helpdesk/user_settings.html
+++ b/src/helpdesk/templates/helpdesk/user_settings.html
@@ -1,4 +1,4 @@
-{% extends "helpdesk/base.html" %}{% load i18n bootstrap4form %}
+{% extends "helpdesk/base.html" %}{% load i18n bootstrap5_form %}
 
 {% block helpdesk_title %}{% trans "Change User Settings" %}{% endblock %}
 
@@ -19,7 +19,7 @@
 {% block form_content %}
 <form role="form" method='post' action='./'>
     {% csrf_token %}
-    {{ form|bootstrap4form }}
+    {% bootstrap5_form form %}
     <div class="mb-3">
       <input type="submit" value="Submit"/>
     </div>

--- a/src/helpdesk/templatetags/bootstrap5_form.py
+++ b/src/helpdesk/templatetags/bootstrap5_form.py
@@ -1,0 +1,84 @@
+"""
+Renders a form with Bootstrap 5 markup, replacing the django-bootstrap4-form
+dependency.
+
+That package emitted classes from Bootstrap 3 (`form-group`, `control-label`,
+`has-error`, `<div class="checkbox">`), none of which exist in the Bootstrap 5
+stylesheet the project ships, so the affected fields lost their spacing and
+their checkboxes and radios went unstyled.
+
+Usage in a template::
+
+    {% load bootstrap5_form %}
+    {% bootstrap5_form form %}
+"""
+
+from django import forms
+from django.template import Library
+
+register = Library()
+
+# Bootstrap 5 wants a different class per widget family. This cannot be applied
+# from the template, because a widget rendered through {{ field }} has already
+# had its attributes resolved, so it is done here before rendering instead.
+SELECT_CLASS = "form-select"
+CHECK_CLASS = "form-check-input"
+CONTROL_CLASS = "form-control"
+
+# Bootstrap 4 name, no effect in Bootstrap 5, which styles file inputs with the
+# ordinary form-control.
+OBSOLETE_CLASSES = {"form-control-file"}
+
+
+def widget_class(widget):
+    """The Bootstrap 5 class the given widget family needs, or None to leave it."""
+    if isinstance(widget, (forms.HiddenInput, forms.MultipleHiddenInput)):
+        return None
+    if isinstance(widget, (forms.CheckboxInput, forms.RadioSelect)):
+        return CHECK_CLASS
+    if isinstance(widget, forms.CheckboxSelectMultiple):
+        return CHECK_CLASS
+    if isinstance(widget, forms.Select):
+        return SELECT_CLASS
+    return CONTROL_CLASS
+
+
+def apply_classes(form):
+    """Give every widget the class its Bootstrap 5 family requires.
+
+    Classes already set in forms.py are kept: several widgets declare
+    `form-control` there, and some carry sizing or behaviour classes unrelated to
+    Bootstrap. Running this twice on the same form is harmless.
+    """
+    for name, field in form.fields.items():
+        wanted = widget_class(field.widget)
+        if wanted is None:
+            continue
+        classes = [
+            c
+            for c in field.widget.attrs.get("class", "").split()
+            if c not in OBSOLETE_CLASSES and c != wanted and c != "is-invalid"
+        ]
+        classes.insert(0, wanted)
+        if form.is_bound and form[name].errors:
+            classes.append("is-invalid")
+        field.widget.attrs["class"] = " ".join(classes)
+
+
+@register.filter
+def is_checkbox(field):
+    return isinstance(field.field.widget, forms.CheckboxInput)
+
+
+@register.filter
+def is_choice_group(field):
+    """Radio buttons and multiple checkboxes render one input per choice."""
+    return isinstance(
+        field.field.widget, (forms.RadioSelect, forms.CheckboxSelectMultiple)
+    )
+
+
+@register.inclusion_tag("helpdesk/include/form.html")
+def bootstrap5_form(form):
+    apply_classes(form)
+    return {"form": form}

--- a/src/helpdesk/templatetags/bootstrap5_form.py
+++ b/src/helpdesk/templatetags/bootstrap5_form.py
@@ -25,6 +25,12 @@ SELECT_CLASS = "form-select"
 CHECK_CLASS = "form-check-input"
 CONTROL_CLASS = "form-control"
 
+# Exactly one of these belongs on a widget: `form-control` sets `width: 100%`,
+# which stretches a checkbox out of square if it is left alongside
+# `form-check-input`. Whichever one the widget family calls for replaces the
+# others, so a wrong class set in forms.py cannot leak into the markup.
+FAMILY_CLASSES = frozenset({SELECT_CLASS, CHECK_CLASS, CONTROL_CLASS})
+
 # Bootstrap 4 name, no effect in Bootstrap 5, which styles file inputs with the
 # ordinary form-control.
 OBSOLETE_CLASSES = {"form-control-file"}
@@ -46,9 +52,10 @@ def widget_class(widget):
 def apply_classes(form):
     """Give every widget the class its Bootstrap 5 family requires.
 
-    Classes already set in forms.py are kept: several widgets declare
-    `form-control` there, and some carry sizing or behaviour classes unrelated to
-    Bootstrap. Running this twice on the same form is harmless.
+    Classes already set in forms.py are kept, so sizing and behaviour classes
+    such as `date-field` survive. The one exception is the family classes, which
+    are mutually exclusive and so are replaced rather than accumulated. Running
+    this twice on the same form is harmless.
     """
     for name, field in form.fields.items():
         wanted = widget_class(field.widget)
@@ -57,7 +64,9 @@ def apply_classes(form):
         classes = [
             c
             for c in field.widget.attrs.get("class", "").split()
-            if c not in OBSOLETE_CLASSES and c != wanted and c != "is-invalid"
+            if c not in OBSOLETE_CLASSES
+            and c not in FAMILY_CLASSES
+            and c != "is-invalid"
         ]
         classes.insert(0, wanted)
         if form.is_bound and form[name].errors:

--- a/standalone/config/settings.py
+++ b/standalone/config/settings.py
@@ -49,7 +49,6 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "django.contrib.sites",
     "django.contrib.humanize",
-    "bootstrap4form",
     "helpdesk",  # This is us!
     "rest_framework",  # required for the API
 ]

--- a/standalone/requirements.txt
+++ b/standalone/requirements.txt
@@ -3,7 +3,6 @@ gunicorn
 psycopg2-binary
 django
 
-django-bootstrap4-form
 email-reply-parser
 markdown
 beautifulsoup4

--- a/tests/test_form_rendering.py
+++ b/tests/test_form_rendering.py
@@ -1,0 +1,141 @@
+"""
+Forms are rendered by helpdesk's own Bootstrap 5 templates rather than by
+django-bootstrap4-form, which emitted Bootstrap 3 markup into a Bootstrap 5 UI.
+
+These tests assert the markup the stylesheet we ship actually understands, and
+assert the absence of the classes that used to be emitted, so a regression to
+the old rendering fails here rather than being noticed by a user.
+"""
+
+from django import forms
+from django.template import Context, Template
+from django.test import TestCase
+from django.urls import reverse
+
+from helpdesk.models import Queue
+from helpdesk.templatetags.bootstrap5_form import apply_classes
+
+from .helpers import get_staff_user
+
+# Classes emitted by the old dependency. None of them exists in Bootstrap 5.
+LEGACY_CLASSES = ["form-group", "control-label", "has-error"]
+
+
+class SampleForm(forms.Form):
+    text = forms.CharField(label="Text", help_text="Some help")
+    choice = forms.ChoiceField(label="Choice", choices=[("a", "A"), ("b", "B")])
+    agree = forms.BooleanField(label="Agree", required=False)
+    radio = forms.ChoiceField(
+        label="Radio", choices=[("x", "X"), ("y", "Y")], widget=forms.RadioSelect
+    )
+    secret = forms.CharField(widget=forms.HiddenInput, required=False)
+    preset = forms.CharField(
+        label="Preset", widget=forms.TextInput(attrs={"class": "form-control custom"})
+    )
+
+
+def render(form):
+    return Template("{% load bootstrap5_form %}{% bootstrap5_form form %}").render(
+        Context({"form": form})
+    )
+
+
+class WidgetClassTestCase(TestCase):
+    def test_each_widget_family_gets_its_bootstrap5_class(self):
+        form = SampleForm()
+        apply_classes(form)
+        attrs = {
+            name: f.widget.attrs.get("class", "") for name, f in form.fields.items()
+        }
+        self.assertIn("form-control", attrs["text"])
+        self.assertIn("form-select", attrs["choice"])
+        self.assertIn("form-check-input", attrs["agree"])
+        self.assertIn("form-check-input", attrs["radio"])
+
+    def test_hidden_widgets_are_left_alone(self):
+        form = SampleForm()
+        apply_classes(form)
+        self.assertEqual(form.fields["secret"].widget.attrs.get("class", ""), "")
+
+    def test_classes_already_set_in_forms_py_are_kept(self):
+        form = SampleForm()
+        apply_classes(form)
+        classes = form.fields["preset"].widget.attrs["class"].split()
+        self.assertIn("custom", classes)
+        self.assertEqual(classes.count("form-control"), 1, classes)
+
+    def test_applying_twice_does_not_duplicate(self):
+        form = SampleForm()
+        apply_classes(form)
+        apply_classes(form)
+        for name, field in form.fields.items():
+            classes = field.widget.attrs.get("class", "").split()
+            self.assertEqual(len(classes), len(set(classes)), f"{name}: {classes}")
+
+    def test_invalid_fields_are_marked(self):
+        form = SampleForm(data={"text": "", "choice": "a", "radio": "x", "preset": "p"})
+        self.assertFalse(form.is_valid())
+        apply_classes(form)
+        self.assertIn("is-invalid", form.fields["text"].widget.attrs["class"])
+        self.assertNotIn("is-invalid", form.fields["preset"].widget.attrs["class"])
+
+
+class RenderedMarkupTestCase(TestCase):
+    def test_layout_is_bootstrap5(self):
+        html = render(SampleForm())
+        self.assertIn('class="mb-3"', html)
+        self.assertIn('class="form-label', html)
+        self.assertIn("form-check-label", html)
+        self.assertIn('class="form-text"', html)
+
+    def test_no_legacy_classes_remain(self):
+        html = render(SampleForm())
+        for legacy in LEGACY_CLASSES:
+            self.assertNotIn(legacy, html, f"{legacy} should not be emitted any more")
+
+    def test_hidden_fields_are_rendered_without_a_wrapper(self):
+        html = render(SampleForm())
+        self.assertIn('name="secret"', html)
+        self.assertNotIn("Secret", html)
+
+    def test_errors_are_visible_without_relying_on_a_sibling(self):
+        """`invalid-feedback` alone is only revealed by an adjacent
+        `.is-invalid`, which does not hold for the choice groups."""
+        form = SampleForm(data={"text": "", "choice": "a", "radio": "x", "preset": "p"})
+        self.assertFalse(form.is_valid())
+        html = render(form)
+        self.assertIn("invalid-feedback d-block", html)
+
+    def test_non_field_errors_use_a_dismissible_alert(self):
+        class Failing(forms.Form):
+            def clean(self):
+                raise forms.ValidationError("nope")
+
+        html = render(Failing(data={}))
+        self.assertIn("alert alert-danger", html)
+        self.assertIn("data-bs-dismiss", html)
+        self.assertNotIn("data-dismiss=", html.replace("data-bs-dismiss=", ""))
+
+
+class RealPagesTestCase(TestCase):
+    """The three pages that used the old filter must still render."""
+
+    def setUp(self):
+        self.queue = Queue.objects.create(
+            title="Queue", slug="q", allow_public_submission=True
+        )
+        self.user = get_staff_user()
+
+    def assert_bootstrap5(self, response):
+        self.assertEqual(response.status_code, 200)
+        html = response.content.decode()
+        self.assertIn("mb-3", html)
+        for legacy in LEGACY_CLASSES:
+            self.assertNotIn(legacy, html)
+
+    def test_public_ticket_form(self):
+        self.assert_bootstrap5(self.client.get(reverse("helpdesk:home")))
+
+    def test_user_settings_form(self):
+        self.client.login(username=self.user.username, password="password")
+        self.assert_bootstrap5(self.client.get(reverse("helpdesk:user_settings")))

--- a/tests/test_form_rendering.py
+++ b/tests/test_form_rendering.py
@@ -32,6 +32,13 @@ class SampleForm(forms.Form):
     preset = forms.CharField(
         label="Preset", widget=forms.TextInput(attrs={"class": "form-control custom"})
     )
+    # Declares the class of the wrong family, as the custom fields built in
+    # forms.py used to: `form-control` stretches a checkbox out of square.
+    mislabelled = forms.BooleanField(
+        label="Mislabelled",
+        required=False,
+        widget=forms.CheckboxInput(attrs={"class": "form-control keep-me"}),
+    )
 
 
 def render(form):
@@ -63,6 +70,16 @@ class WidgetClassTestCase(TestCase):
         classes = form.fields["preset"].widget.attrs["class"].split()
         self.assertIn("custom", classes)
         self.assertEqual(classes.count("form-control"), 1, classes)
+
+    def test_family_classes_are_exclusive(self):
+        """A widget carrying the wrong family class must not keep it: the two
+        set `width` differently and the checkbox ends up rectangular."""
+        form = SampleForm()
+        apply_classes(form)
+        classes = form.fields["mislabelled"].widget.attrs["class"].split()
+        self.assertIn("form-check-input", classes)
+        self.assertNotIn("form-control", classes)
+        self.assertIn("keep-me", classes)
 
     def test_applying_twice_does_not_duplicate(self):
         form = SampleForm()


### PR DESCRIPTION
Closes #1375, following @uhurusurfa's call for option 2.

## The problem

The UI ships Bootstrap 5.3.8, but form fields were rendered by `django-bootstrap4-form`, whose markup is largely Bootstrap **3**: `form-group`, `control-label`, `has-error`, `<div class="checkbox">`. None of those classes exists in the stylesheet we load, so the affected fields lost their bottom margin and checkboxes rendered unstyled.

The org's own `django-bootstrap5-form` looked like the obvious replacement, but it pins `django<4.0` while we require `django>=4.2`, so it cannot be installed alongside us. With the filter used in exactly three templates, owning the rendering is cheaper than maintaining a published package or adopting a larger one.

## What this does

Adds `{% bootstrap5_form form %}` and two templates under `helpdesk/include/`.

Widget classes are assigned in Python rather than in the template, because a widget rendered through `{{ field }}` has already resolved its attributes and cannot be given a class afterwards. Selects get `form-select`, checkboxes and radios `form-check-input`, everything else `form-control`, and hidden inputs are left alone. Classes already declared in `forms.py` are preserved when they are unrelated to the Bootstrap widget family, and the obsolete `form-control-file` is dropped.

The three family classes are treated as mutually exclusive. `form-control` sets `width: 100%` while `form-check-input` sizes a square box, so a widget carrying both renders wrong. This is not hypothetical: `forms.py` declared `form-control` on the checkbox and the select it builds for custom fields, which is why a boolean custom field used to reach the browser as `form-check-input form-control` and render 26px wide instead of 16px. Those two declarations are corrected at the source as well.

Errors use `invalid-feedback d-block` rather than plain `invalid-feedback`. The latter is only revealed by an adjacent `.is-invalid`, and that relationship does not hold for the choice groups, where the inputs are nested one level deeper.

## Also in here

- The four `{% load bootstrap4form %}` lines in templates that never called the filter are gone: `create_ticket.html`, `public_homepage.html`, `ticket.html`, `registration/login.html`.
- `bootstrap4form` is removed from `INSTALLED_APPS` in `demodesk`, `standalone` and `quicktest.py`, and from the example in `docs/install.rst`.
- `packaging` is dropped. It was only ever declared because `django-bootstrap4-form` imports it without declaring it, and nothing else in a default install needs it.
- `docs/upgrade.rst` gains a note telling operators to drop `'bootstrap4form'` from their own `INSTALLED_APPS`, and what to do if they have overridden one of the three templates.
- The submit button on the user settings form was a bare `<input type="submit">` with no class and no `gettext` call. It now follows `edit_ticket.html`.

## Verification

Full suite passes: 253 tests, 2 skipped, with `bootstrap4form` and `packaging` genuinely uninstalled rather than merely undeclared. Thirteen of those tests are new, covering the class assignment per widget family, the exclusivity between families, idempotence, preservation of unrelated classes, the error markup, and that the three previously affected pages still render without any legacy class.

## Before and after

Captured on the demo project at the same viewport, with the same fixtures on both sides. Two custom fields were added to the demo database to exercise the widgets the default fixtures do not cover: a `boolean` one and a `list` one.

### Public ticket form

Fields have no bottom margin before, so each label sits against the previous field's help text. Selects are indistinguishable from text inputs. After, spacing is even and selects carry their chevron.

<img width="1280" height="1321" alt="before-public-submit" src="https://github.com/user-attachments/assets/3ec94ede-083e-422c-a784-9116d0372519" />

<img width="1280" height="1550" alt="after-public-submit" src="https://github.com/user-attachments/assets/c6fe9e46-01b7-4187-ac00-3ecc56f632b5" />

### Public ticket form, submitted empty

Before, the error text is red but no field is marked, and on Description and E-Mail the message runs into the help text on the same line. After, invalid fields get a red border and an alert icon, and each message sits on its own line.

<img width="1280" height="1443" alt="before-public-submit-errors" src="https://github.com/user-attachments/assets/3bd64093-3302-4183-b8a4-7cd2cca504d2" />

<img width="1280" height="1724" alt="after-public-submit-errors" src="https://github.com/user-attachments/assets/c94528e0-0c4f-4a1f-804f-7f98873705dc" />

### User settings

The clearest case. Before, the checkboxes are unstyled browser defaults with the label and help text running together on one overflowing line, and the submit button is unstyled. After, the checkboxes are Bootstrap 5 controls, help text sits under its label, and the button is styled.

<img width="1280" height="1000" alt="before-user-settings" src="https://github.com/user-attachments/assets/5739c9fe-da69-48cb-8918-1cd67cbf83cb" />

<img width="1280" height="1000" alt="after-user-settings" src="https://github.com/user-attachments/assets/2992509d-719d-4e23-b80a-3ef64d2fbe34" />

### Edit ticket

Note the `Needs a callback?` custom field. Before, it is a full width empty rectangle with no visible checkbox at all, which is the `form-control` bug described above. After, it is a 16px checkbox with its label and help text, and `Business impact` is a proper `form-select`.

<img width="1280" height="1414" alt="before-ticket-edit" src="https://github.com/user-attachments/assets/09e8c6be-799c-4ccf-b402-e07c776e8e82" />

<img width="1280" height="1686" alt="after-ticket-edit" src="https://github.com/user-attachments/assets/f3dab535-4330-4327-8569-d08e10f30248" />

## Note for reviewers

`FormControlDeleteFormSet.deletion_widget` in `forms.py` still declares `form-control` on a checkbox. It is rendered by the checklist templates rather than through `bootstrap5_form`, so this branch does not reach it and I have left it for a separate change.

The codebase contains no `RadioSelect`, so radio groups never render on any of these pages today. The tag handles them, and the tests cover them, but nobody should go looking for a visual difference there.
