### PR TITLE
docs: correct what happens if you publish before the CVE is assigned

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,7 +37,9 @@ Everything below is theirs to drive, not to delegate and hope.
 
 2. **Request the CVE at draft stage**, not at the end.
    GitHub quotes up to three working days to review the request, and requesting it discloses nothing, so it may as well run in parallel with the fix.
-   Publishing before the identifier is assigned is fine: it gets attached to the advisory when their review completes.
+   If the identifier has not arrived by the time everything else is ready, decide deliberately whether to wait rather than assuming it will catch up.
+   Publishing first does not simply defer the assignment: another CNA can pick the published advisory up and assign a CVE from it, with their own severity and their own wording.
+   That is what happened to GHSA-q46c-8w98-fq2g, which VulnCheck assigned CVE-2026-73531 from five days after we published, while GitHub's own review was still pending.
 
 3. **Fill in the affected version range honestly.**
    Work out when the vulnerable code was actually introduced rather than assuming it was recent, and make the upper bound match the version that will carry the fix.


### PR DESCRIPTION
Step 2 told us that publishing before the CVE identifier arrives is fine, because it gets attached once GitHub's review completes. That turned out to be wrong, and we found out the expensive way three days after merging it.

GitHub declined our request for GHSA-q46c-8w98-fq2g as a duplicate. VulnCheck had already assigned **CVE-2026-73531** on 13 August, five days after we published, deriving it from our own advisory: our GHSA is the first reference listed on the [NVD record](https://nvd.nist.gov/vuln/detail/CVE-2026-73531).

So the identifier exists and the advisory now carries it, but the record is theirs: their wording, and their severity of 6.1 where we had assessed 8.1. Nothing was lost that matters much here, but we did hand over control of a record about our own project without meaning to.

Publishing early is still often the right call, since step 5 wants the gap between merging and an installable release measured in minutes. The correction is only that this is a trade-off to make deliberately, rather than a step with no consequence.
