### PR TITLE
hide the queue picker when only one queue exists, across create/edit ticket forms

### DIFF
--- a/src/helpdesk/forms.py
+++ b/src/helpdesk/forms.py
@@ -147,6 +147,14 @@ class EditTicketForm(CustomFieldMixin, forms.ModelForm):
             "This ticket is merged into the selected ticket."
         )
 
+        # If there is only a single queue configured, there is nothing
+        # meaningful to choose, so hide the field entirely.
+        if "queue" in self.fields:
+            queues = Queue.objects.all()
+            if queues.count() == 1:
+                self.fields["queue"].initial = queues.first().pk
+                self.fields["queue"].widget = forms.HiddenInput()
+
         for field in CustomField.objects.all():
             initial_value = None
             try:
@@ -476,6 +484,12 @@ class TicketForm(AbstractTicketForm):
         super().__init__(*args, **kwargs)
         if queue_choices:
             self.fields["queue"].choices = queue_choices
+            # If there is only a single queue to choose from, there is
+            # nothing meaningful to choose, so hide the field and default
+            # to it.
+            if len(queue_choices) == 1:
+                self.fields["queue"].initial = queue_choices[0][0]
+                self.fields["queue"].widget = forms.HiddenInput()
         self.fields["body"].required = body_reqd
         self.fields["assigned_to"].choices = [("", "--------")] + [
             (u.id, u.get_username())

--- a/src/helpdesk/templates/helpdesk/ticket.html
+++ b/src/helpdesk/templates/helpdesk/ticket.html
@@ -299,15 +299,19 @@
                           {% endfor %}
                         </select>
                       </div>
-                      <div class="col-md-3">
-                        <label class="form-label" for="id_queue">{% translate "Queue" %}</label>
-                        <select class="form-select" id="id_queue" name="queue">
-                          {% for queue_id, queue_name in queues %}
-                            <option value="{{ queue_id }}"
-                                    {% if queue_id == ticket.queue.id %} selected{% endif %}>{{ queue_name }}</option>
-                          {% endfor %}
-                        </select>
-                      </div>
+                      {% if queues|length > 1 %}
+                        <div class="col-md-3">
+                          <label class="form-label" for="id_queue">{% translate "Queue" %}</label>
+                          <select class="form-select" id="id_queue" name="queue">
+                            {% for queue_id, queue_name in queues %}
+                              <option value="{{ queue_id }}"
+                                      {% if queue_id == ticket.queue.id %} selected{% endif %}>{{ queue_name }}</option>
+                            {% endfor %}
+                          </select>
+                        </div>
+                      {% else %}
+                        <input type="hidden" id="id_queue" name="queue" value="{{ ticket.queue.id }}" />
+                      {% endif %}
                       <div class="col-md-3">
                         <label class="form-label" for="id_due_date">{% translate "Due on" %}</label>
                         {{ form.due_date }}

--- a/tests/test_single_queue_hiding.py
+++ b/tests/test_single_queue_hiding.py
@@ -1,0 +1,77 @@
+"""
+When only a single queue is configured, there is nothing meaningful for a
+user to choose, so the queue selector should be hidden (and default to that
+queue) rather than shown as a single-option dropdown.
+
+See: https://github.com/django-helpdesk/django-helpdesk/issues/289
+"""
+
+from django import forms
+from django.test import TestCase
+from django.urls import reverse
+
+from helpdesk.forms import EditTicketForm, TicketForm
+from helpdesk.models import Queue, Ticket
+
+from .helpers import get_staff_user
+
+
+class TicketFormSingleQueueTestCase(TestCase):
+    def test_queue_hidden_when_only_one_choice(self):
+        form = TicketForm(queue_choices=[(1, "Products")])
+        self.assertIsInstance(form.fields["queue"].widget, forms.HiddenInput)
+        self.assertEqual(form.fields["queue"].initial, 1)
+
+    def test_queue_shown_when_multiple_choices(self):
+        form = TicketForm(
+            queue_choices=[("", "--------"), (1, "Products"), (2, "Support")]
+        )
+        self.assertNotIsInstance(form.fields["queue"].widget, forms.HiddenInput)
+
+
+class EditTicketFormSingleQueueTestCase(TestCase):
+    def test_queue_hidden_when_only_one_queue_exists(self):
+        queue = Queue.objects.create(title="Products", slug="products")
+        ticket = Ticket.objects.create(
+            title="Test ticket", submitter_email="test@example.com", queue=queue
+        )
+        form = EditTicketForm(instance=ticket)
+        self.assertIsInstance(form.fields["queue"].widget, forms.HiddenInput)
+        self.assertEqual(form.fields["queue"].initial, queue.pk)
+
+    def test_queue_shown_when_multiple_queues_exist(self):
+        queue = Queue.objects.create(title="Products", slug="products")
+        Queue.objects.create(title="Support", slug="support")
+        ticket = Ticket.objects.create(
+            title="Test ticket", submitter_email="test@example.com", queue=queue
+        )
+        form = EditTicketForm(instance=ticket)
+        self.assertNotIsInstance(form.fields["queue"].widget, forms.HiddenInput)
+
+
+class TicketDetailQueueFieldTestCase(TestCase):
+    def setUp(self):
+        self.user = get_staff_user()
+        self.client.login(username=self.user.username, password="password")
+
+    def test_queue_select_hidden_with_single_queue(self):
+        queue = Queue.objects.create(title="Products", slug="products")
+        ticket = Ticket.objects.create(
+            title="Test ticket", submitter_email="test@example.com", queue=queue
+        )
+        response = self.client.get(reverse("helpdesk:view", args=[ticket.id]))
+        html = response.content.decode()
+        self.assertIn(
+            f'<input type="hidden" id="id_queue" name="queue" value="{queue.id}"', html
+        )
+        self.assertNotIn('<select class="form-select" id="id_queue"', html)
+
+    def test_queue_select_shown_with_multiple_queues(self):
+        queue = Queue.objects.create(title="Products", slug="products")
+        Queue.objects.create(title="Support", slug="support")
+        ticket = Ticket.objects.create(
+            title="Test ticket", submitter_email="test@example.com", queue=queue
+        )
+        response = self.client.get(reverse("helpdesk:view", args=[ticket.id]))
+        html = response.content.decode()
+        self.assertIn('<select class="form-select" id="id_queue" name="queue">', html)


### PR DESCRIPTION
fix #289 