### PR TITLE
Update supported key software versions of Django and Python

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
           - python-version: "3.11"
             django-version: "5.2"
         # Define the general matrix for Python with Django
-        python-version: [ "3.12", "3.13", "3.14"]]
+        python-version: [ "3.12", "3.13", "3.14"]
         django-version: ["6.0", "6.1"]
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,19 +16,17 @@ jobs:
     strategy:
       matrix:
         # limit number of matrices by applying sensible combinations
+        # Django 6 only supports Python 3.12+
         include:
-          # Explicitly include Python 3.9 only with Django 4.2
-          - python-version: "3.9"
-            django-version: "4.2"
-          # Explicitly include Python 3.13 only with Django 5.1
-          - python-version: "3.13"
-            django-version: "5.1"
-          # Explicitly include Python 3.14 only with Django 5.2
-          - python-version: "3.14"
+          # Explicitly include Python 3.10 only with Django 5.2
+          - python-version: "3.10"
+            django-version: "5.2"
+          # Explicitly include Python 3.11 only with Django 5.2
+          - python-version: "3.11"
             django-version: "5.2"
         # Define the general matrix for Python with Django
-        python-version: ["3.10", "3.11", "3.12"]
-        django-version: ["4.2", "5.0", "5.1", "5.2"]
+        python-version: [ "3.12", "3.13", "3.14"]]
+        django-version: ["6.0", "6.1"]
     steps:
       - uses: actions/checkout@v5
         with:
@@ -74,12 +72,12 @@ jobs:
           cd ${GITHUB_WORKSPACE} && uv run --no-sync coverage run quicktest.py
 
       - name: Convert coverage to LCOV
-        if: matrix.python-version == '3.12' && matrix.django-version == '5.2'
+        if: matrix.python-version == '3.11' && matrix.django-version == '5.2'
         run: |
           uv run coverage lcov
 
       - name: Upload coverage to Coveralls
-        if: matrix.python-version == '3.12' && matrix.django-version == '5.2'
+        if: matrix.python-version == '3.11' && matrix.django-version == '5.2'
         uses: coverallsapp/github-action@v2
         with:
           file: coverage.lcov

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -17,14 +17,10 @@ Prerequisites
 
 Before getting started, ensure your system meets the following recommended dependencies:
 
-* Python 3.8+
-* Django 3.2 LTS
+* Python 3.10+
+* Django 5.2+
   
 Ensure any extra Django modules you wish to use are compatible before continuing.
-
-**NOTE**: Python 2 support was deprecated in ``django-helpdesk`` as of version 0.2.x
-and completely removed in version 0.3.0. Users that still need Python 2 support should
-remain on version 0.2.x.
 
 
 Getting The Code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "django-helpdesk"
-version = "2.3.3"
+version = "2.4.0"
 description = "Django-powered ticket tracker for your helpdesk"
 authors = [
     {name = "Ross Poulton", email = "ross@rossp.org"},
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 readme = "README.rst"
 license = {text = "BSD-3-Clause"}
 keywords = ["django", "helpdesk", "django-helpdesk", "tickets", "incidents", "cases", "bugs", "track", "support"]
@@ -18,7 +18,7 @@ packages = [
     { include="helpdesk", from="." },
 ]
 dependencies = [
-    "django>=4.2",
+    "django>=5.2",
     # Kept as a hard dependency on purpose: it activates automatically when listed
     # in INSTALLED_APPS, as docs/install.rst suggests, so a copy that follows our
     # own instructions would refuse to start without it.
@@ -38,19 +38,19 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Web Environment",
     "Framework :: Django",
-    "Framework :: Django :: 4.0",
-    "Framework :: Django :: 5.0",
+    "Framework :: Django :: 5.2",
+    "Framework :: Django :: 6.0",
     "Intended Audience :: Customer Service",
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Topic :: Office/Business",
     "Topic :: Software Development :: Bug Tracking",
     "Topic :: Software Development :: Libraries :: Python Modules",
@@ -87,8 +87,7 @@ test = [
     "argparse>=1.4.0",
     "coverage>=7.10.4",
     "factory-boy>=3.3.3",
-    "faker>=37.5.3,<=37.10.0; python_version < '3.10'",
-    "faker>=37.11.0; python_version >= '3.10'",
+    "faker>=37.11.0",
     "freezegun>=1.5.5",
     "isort>=6.0.1",
     "mock>=5.2.0",


### PR DESCRIPTION
Removes no longer supported versions of Python and Django from the documentation and test matrices.

Python 3.10 is 2 months from EOL but left it in for now.
Python 3.14 is about to be released within the next few months so have included it in advance.

Also updates the Django-Helpdesk version allowing us to release now or whenever the team feel is a good point in time given the flurry of development we have seen in the last few weeks.