### PR TITLE
docs: say what django-helpdesk leaves to the deployer

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -121,3 +121,53 @@ The following settings variables control emitting log messages for specific scen
 
 ``HELPDESK_LOG_WARN_WHEN_CC_EMAIL_LINKED_TO_MORE_THAN_1_USER`` (default:``True``)
   There is more than 1 user matching the email address in the CC list.
+
+.. _production-hardening:
+
+Production hardening
+--------------------
+
+django-helpdesk does not attempt to be a hardened deployment on its own, and
+this is worth stating plainly because its default shape is unusual: unlike most
+Django applications, it ships a **public-facing login page** and a **public
+ticket submission form**, so a normal installation is reachable from the
+internet rather than sitting behind an intranet.
+
+The authentication view is a thin wrapper around
+``django.contrib.auth.views.LoginView``, so django-helpdesk inherits Django's
+behaviour and Django deliberately does not rate limit authentication. That means
+the following are the deployer's responsibility, not this project's.
+
+**Rate limiting authentication.** Nothing here limits how many login attempts an
+address may make, so an exposed instance will accept unlimited password
+guessing. Either handle it in front of the application, at your reverse proxy or
+WAF, or install a Django app that does it. `django-axes
+<https://github.com/jazzband/django-axes>`_ and `django-defender
+<https://github.com/kencochrane/django-defender>`_ are the usual choices, and
+either is preferable to us reimplementing lockout logic that would then need a
+cache backend and its own denial-of-service trade-offs.
+
+**Password policy.** Set ``AUTH_PASSWORD_VALIDATORS`` in your settings. Django
+ships validators for minimum length, common passwords and numeric-only
+passwords, and none of them apply unless you configure them.
+
+**Serving attachments.** Attachment content comes from unauthenticated third
+parties, through inbound email and through the public submission form. Do not
+serve ``MEDIA_ROOT`` in a way that renders attachments inline, and see
+``HELPDESK_VALID_EXTENSIONS`` for the extensions accepted on upload.
+
+**Transport and cookies.** Serve the site over HTTPS. If you terminate TLS at a
+proxy, set the ``SECURE_PROXY_SSL_HEADER`` *environment variable* to any
+non-empty value: django-helpdesk then sets Django's ``SECURE_PROXY_SSL_HEADER``
+to ``("HTTP_X_FORWARDED_PROTO", "https")`` and turns on
+``SESSION_COOKIE_SECURE`` and ``CSRF_COOKIE_SECURE`` for you. Without it, set
+those two yourself.
+
+**Turning off what you do not use.** ``HELPDESK_API_ENABLED = False`` removes the
+REST API routes entirely, and ``HELPDESK_SUBMIT_A_TICKET_PUBLIC = False`` removes
+the public submission form. Reducing the exposed surface is cheaper than
+defending it.
+
+Django's own `deployment checklist
+<https://docs.djangoproject.com/en/stable/howto/deployment/checklist/>`_ covers
+the rest and is worth running through before going live.

--- a/docs/standalone.rst
+++ b/docs/standalone.rst
@@ -75,6 +75,8 @@ Configuration for Production Use
 
 2. For custom configurations, bindmount a ``local_settings.py`` into ``/opt/django-helpdesk/standalone/config/local_settings.py``.
 
+   See :ref:`production-hardening` for what django-helpdesk leaves to the deployer, in particular rate limiting the login page.
+
 3. To customize the logo in the top-left corner of the helpdesk:
 
    .. code-block:: html


### PR DESCRIPTION
Comes out of triaging GHSA-q42j-c994-653f, where @cialoo reported that the login page accepts unlimited authentication attempts.

I agree with @uhurusurfa and @DavidVadnais that it is not a defect here: `helpdesk/views/login.py` is a twenty-line wrapper around `django.contrib.auth.views.LoginView`, so there is no authentication logic of ours to harden and Django deliberately does not rate limit. But the reporter's second comment lands, and David conceded it: nothing in our documentation says hardening is the deployer's job.

That is worth more than politeness here, because our default shape is unusual for a Django application. We ship a **public-facing login page** and a **public ticket submission form**, so a normal installation is reachable from the internet rather than sitting on an intranet. "Handle this in front of the application" is correct advice that we had simply never given.

## What this adds

A `Production hardening` section in `docs/configuration.rst`, cross-referenced from the standalone production list, covering:

* rate limiting authentication, pointing at `django-axes` and `django-defender` rather than reimplementing lockout logic that would need a cache backend and bring its own denial-of-service trade-offs
* `AUTH_PASSWORD_VALIDATORS`, which do nothing unless configured
* attachment serving, since attachment content comes from unauthenticated third parties
* transport and cookies
* turning off unused surface with `HELPDESK_API_ENABLED` and `HELPDESK_SUBMIT_A_TICKET_PUBLIC`

## Two things that were not written down anywhere

Both found while writing this, and both are existing behaviour rather than proposals:

* Setting the **`SECURE_PROXY_SSL_HEADER` environment variable** to any non-empty value makes `helpdesk/settings.py` set Django's `SECURE_PROXY_SSL_HEADER` and turn on `SESSION_COOKIE_SECURE` and `CSRF_COOKIE_SECURE`. Useful, and undocumented until now.
* `HELPDESK_API_ENABLED = False` removes the `api/` routes entirely, which is also the workaround we gave for GHSA-g9r9-54m2-m6g5.

## Unrelated finding

The docs do not build on the minimum supported Python. `docs/conf.py` imports `tomllib`, which is standard library from 3.11, while `pyproject.toml` declares `requires-python = ">=3.10"`. I built these changes with 3.13 to validate them. Not fixed here since it is unrelated, but worth an issue.

Built with `sphinx-build -W --keep-going`, no warnings.
