### PR TITLE
docs: give settings and command options their own directives

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -84,7 +84,7 @@ Here is an example with form-data (curl default) ::
 
 Accessing the endpoint ``/api/followups/`` with a **POST** request will let you create a new followup on a ticket.
 
-This time, you can attach multiple files thanks to the `attachments` field. Here is an example ::
+This time, you can attach multiple files thanks to the ``attachments`` field. Here is an example ::
 
     curl --location --request POST 'http://127.0.0.1:8000/api/followups/' \
     --header 'Authorization: Basic YWRtaW46YWRtaW4=' \

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -193,6 +193,17 @@ html_split_index = False
 htmlhelp_basename = "django-helpdeskdoc"
 
 
+# -- Options for EPUB output ---------------------------------------------
+
+# The EPUB builder has no sidebar and no favicon, so it never references the
+# logo files. Keep them out of the archive: their formats are not part of the
+# EPUB media types and Sphinx warns about every file it cannot map.
+epub_exclude_files = [
+    "_static/logo.avif",
+    "_static/logo.ico",
+]
+
+
 # -- Options for LaTeX output --------------------------------------------
 
 # The paper size ('letter' or 'a4').
@@ -250,3 +261,19 @@ man_pages = [
         1,
     )
 ]
+
+
+# -- Custom object types -------------------------------------------------
+
+
+def setup(app):
+    # django-helpdesk settings live in the deployer's own settings.py, so they
+    # are not objects of any Python domain module. Registering them as their
+    # own object type gives each one an anchor and an index entry, and makes
+    # :setting:`NAME` a cross-reference the build resolves.
+    app.add_object_type(
+        "setting",
+        "setting",
+        objname="django-helpdesk setting",
+        indextemplate="pair: %s; setting",
+    )

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -27,9 +27,9 @@ Before django-helpdesk will be much use, you need to do some basic configuration
 
    **Debugging Email Extraction**
 
-   You can run the management command manually from the command line with additional commands option ``debug_to_stdout``. Set this when manually running the command from a terminal so that additional debugging about which queues are being processed is written to stdout (console by default)::
+   You can run the management command manually from the command line with the :option:`--debug_to_stdout <get_email --debug_to_stdout>` option. Set this when manually running the command from a terminal so that additional debugging about which queues are being processed is written to stdout (console by default)::
 
-       **/path/to/helpdesksite/manage.py get_email --debug_to_stdout**
+    /path/to/helpdesksite/manage.py get_email --debug_to_stdout
 
 4. If you wish to automatically escalate tickets based on their age, set up a cronjob to run the escalation command on a regular basis::
 
@@ -37,7 +37,7 @@ Before django-helpdesk will be much use, you need to do some basic configuration
 
    This will run the escalation process hourly, using the 'Escalation Days' setting for each queue to determine which tickets to escalate.
 
-   To notify users of outstanding tickets without adding an entry to the ticket, use the `notify-only` flag. This will send the emails without creating a follow-up::
+   To notify users of outstanding tickets without adding an entry to the ticket, use the :option:`--notify-only <escalate_tickets --notify-only>` flag. This will send the emails without creating a follow-up::
 
     0 * * * * /path/to/helpdesksite/manage.py escalate_tickets --notify-only
 
@@ -72,6 +72,78 @@ Before django-helpdesk will be much use, you need to do some basic configuration
 8. If you wish to use SOCKS4/5 proxy with Helpdesk Queue email operations, install PySocks manually. Please note that mixing both SOCKS and non-SOCKS email sources for different queues is only supported under Python 2; on Python 3, SOCKS proxy support is all-or-nothing: either all queue email sources must use SOCKS or none may use it. If you need this functionality on Python 3 please `let us know <https://github.com/django-helpdesk/django-helpdesk/issues/new>`_.
 
 You're now up and running! Happy ticketing.
+
+
+Management commands
+-------------------
+
+The commands below are the ones referenced in the steps above. Run them through
+your project's ``manage.py``, and remember that a cronjob needs the relevant
+Django environment variables set.
+
+.. program:: get_email
+
+``get_email``
+^^^^^^^^^^^^^
+
+Import e-mail from the inboxes configured on each queue and turn the messages
+into tickets or follow-ups.
+
+.. option:: --quiet
+
+   Hide details about each queue and message as they are processed.
+
+.. option:: --debug_to_stdout
+
+   Log additional messaging to stdout, including which queues are being
+   processed. Useful when running the command by hand.
+
+.. program:: escalate_tickets
+
+``escalate_tickets``
+^^^^^^^^^^^^^^^^^^^^
+
+Raise the priority of tickets that have gone untouched for longer than their
+queue's *Escalation Days* setting.
+
+.. option:: -q <slug ...>, --queues <slug ...>
+
+   Queue slugs to include, as a space separated list. All queues by default.
+
+.. option:: -x, --escalate-verbosely
+
+   Display the tickets that were escalated.
+
+.. option:: -n, --notify-only
+
+   Send the e-mail reminders without escalating the tickets, so no follow-up is
+   added to the ticket.
+
+.. program:: create_escalation_exclusions
+
+``create_escalation_exclusions``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Create the calendar entries that keep given days out of the escalation
+calculation.
+
+.. option:: -d <day ...>, --days <day ...>
+
+   Required. Days of the week to exclude (``monday``, ``tuesday``, and so on),
+   as a space separated list.
+
+.. option:: -o <n>, --occurrences <n>
+
+   How many weeks ahead to exclude those days. Defaults to ``1``.
+
+.. option:: -q <slug ...>, --queues <slug ...>
+
+   Queue slugs to include, as a space separated list. All queues by default.
+
+.. option:: -x, --exclude-verbosely
+
+   Display the list of dates that were excluded.
+
 
 Queue settings via admin interface
 ----------------------------------
@@ -154,7 +226,7 @@ passwords, and none of them apply unless you configure them.
 **Serving attachments.** Attachment content comes from unauthenticated third
 parties, through inbound email and through the public submission form. Do not
 serve ``MEDIA_ROOT`` in a way that renders attachments inline, and see
-``HELPDESK_VALID_EXTENSIONS`` for the extensions accepted on upload.
+:setting:`HELPDESK_VALID_EXTENSIONS` for the extensions accepted on upload.
 
 **Transport and cookies.** Serve the site over HTTPS. If you terminate TLS at a
 proxy, set the ``SECURE_PROXY_SSL_HEADER`` *environment variable* to any

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -109,7 +109,7 @@ errors with trying to create User settings.
    This line will have to come *after* any other lines in your urls.py such
    as those used by the Django admin.
 
-   Note that the `helpdesk` namespace is no longer required for Django 1.9+
+   Note that the ``helpdesk`` namespace is no longer required for Django 1.9+
    and you can use a different namespace.
    However, it is recommended to use the default namespace name for clarity.
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -19,7 +19,6 @@ First, django-helpdesk needs  ``django.core.context_processors.request`` activat
         },
     ]
 
-
 The following settings can be changed in your ``settings.py`` file to help change the way django-helpdesk operates. There are quite a few settings available to toggle functionality within django-helpdesk.
 
 
@@ -44,33 +43,56 @@ Access control & Security
 
 These settings can be used to change who can access the helpdesk.
 
-``HELPDESK_PUBLIC_VIEW_PROTECTOR``
-  Function that takes a request and can either return ``None`` granting access to to a public view or a redirect denying access.
+.. setting:: HELPDESK_PUBLIC_VIEW_PROTECTOR
 
-``HELPDESK_STAFF_VIEW_PROTECTOR``
-  Function that takes a request and can either return ``None`` granting access to to a staff view or a redirect denying access.
+   Function that takes a request and can either return ``None`` granting access to to a public view or a redirect denying access.
 
-``HELPDESK_REDIRECT_TO_LOGIN_BY_DEFAULT`` (default:``False``)
-  When a user visits ``/``, should we redirect to the login page instead of the default homepage?
+.. setting:: HELPDESK_STAFF_VIEW_PROTECTOR
 
-``HELPDESK_ANON_ACCESS_RAISES_404`` (default:``False``)
-  If ``True``, redirects user to a 404 page when attempting to reach ticket pages while not logged in, rather than redirecting to a login screen.
+   Function that takes a request and can either return ``None`` granting access to to a staff view or a redirect denying access.
+
+.. setting:: HELPDESK_REDIRECT_TO_LOGIN_BY_DEFAULT
+
+   *Default:* ``False``
+
+   When a user visits ``/``, should we redirect to the login page instead of the default homepage?
+
+.. setting:: HELPDESK_ANON_ACCESS_RAISES_404
+
+   *Default:* ``False``
+
+   If ``True``, redirects user to a 404 page when attempting to reach ticket pages while not logged in, rather than redirecting to a login screen.
 
 Settings related to attachments
 
-``HELPDESK_ENABLE_ATTACHMENTS`` (default:``True``)
-  If set to ``True``, files can be attached to tickets and followups, and emails are searched for attachments which are then attached to the ticket.  Also enables the ``HELPDESK_ALWAYS_SAVE_INCOMING_EMAIL_MESSAGE`` setting.
+.. setting:: HELPDESK_ENABLE_ATTACHMENTS
 
-  .. caution::
-     Set this to False, unless you have secured access to the uploaded files. Otherwise anyone on the Internet will be able to download your ticket attachments.
+   *Default:* ``True``
 
-     Attachments are enabled by default for backwards compatibility.
+   If set to ``True``, files can be attached to tickets and followups, and emails are searched for attachments which are then attached to the ticket.  Also enables the :setting:`HELPDESK_ALWAYS_SAVE_INCOMING_EMAIL_MESSAGE` setting.
 
-``HELPDESK_VALID_EXTENSIONS`` (default:``['.txt', '.asc', '.htm', '.html', '.pdf', '.doc', '.docx', '.odt', '.jpg', '.png', '.eml']``)
-  Valid extensions for file types that can be attached to tickets. Note: This used to be called ``VALID_EXTENSIONS`` which is now deprecated.
+   .. caution::
+      Set this to False, unless you have secured access to the uploaded files. Otherwise anyone on the Internet will be able to download your ticket attachments.
 
-``HELPDESK_VALIDATE_ATTACHMENT_TYPES``
-  If you'd like to turn of filtering of helpdesk extension types you can set this to ``False``.
+      Attachments are enabled by default for backwards compatibility.
+
+.. setting:: HELPDESK_VALID_EXTENSIONS
+
+   *Default:* ``['.txt', '.asc', '.htm', '.html', '.pdf', '.doc', '.docx', '.odt', '.jpg', '.png', '.eml']``
+
+   Valid extensions for file types that can be attached to tickets. Note: This used to be called ``VALID_EXTENSIONS`` which is now deprecated.
+
+.. setting:: HELPDESK_VALIDATE_ATTACHMENT_TYPES
+
+   If you'd like to turn of filtering of helpdesk extension types you can set this to ``False``.
+
+.. setting:: HELPDESK_ALWAYS_SAVE_INCOMING_EMAIL_MESSAGE
+
+   *Default:* ``False``
+
+   Any incoming .eml message is saved and available, helps when customer spent some time doing fancy markup which has been corrupted during the ``email-to-ticket-comment`` translate process.
+
+   Requires :setting:`HELPDESK_ENABLE_ATTACHMENTS` to be set to ``True``.
 
 
 Generic Options
@@ -78,70 +100,125 @@ Generic Options
 
 These changes are visible throughout django-helpdesk
 
-``HELPDESK_KANBAN_ENABLED`` (default:``True``)
-  show the Kanban board?
+.. setting:: HELPDESK_KANBAN_ENABLED
 
-``HELPDESK_KANBAN_DEFAULT_DUE_WEEKS`` (default:``2``)
-  Default number of weeks ahead used by the Kanban board's due-date filter (more Scrum like). On first load (no filter parameters in the URL) the board shows tickets due within this many weeks plus any overdue open tickets.
-  Set to ``0`` or ``None`` to show all tickets by default (Makes it more Kanban like - not recommended for large datasets).
+   *Default:* ``True``
 
-``HELPDESK_KANBAN_DEFAULT_RENDER_CLOSED_TICKETS_WEEKS`` (default:``6``)
-  Hides closed and duplicate tickets that have not been modified within this many weeks. Tickets with a ``Closed`` or ``Duplicate`` status whose ``modified`` timestamp is older than the cutoff are excluded from the board.
-  Set to ``0`` or ``None`` to always show all closed and duplicate tickets regardless of age.
+   show the Kanban board?
 
-``HELPDESK_KB_ENABLED`` (default:``True``)
-  Show knowledgebase links?
+.. setting:: HELPDESK_KANBAN_DEFAULT_DUE_WEEKS
 
-``HELPDESK_NAVIGATION_ENABLED`` (default:``False``)
-  Show extended navigation by default, to all users, irrespective of staff status?
+   *Default:* ``2``
 
-``HELPDESK_SHOW_MY_TICKETS_IN_NAV_FOR_STAFF`` (default:``True``)
-  Show "My tickets" for staff. Typically used for help desk deployments that allow staff to create tickets to action other staff members.
+   Default number of weeks ahead used by the Kanban board's due-date filter (more Scrum like). On first load (no filter parameters in the URL) the board shows tickets due within this many weeks plus any overdue open tickets.
+   Set to ``0`` or ``None`` to show all tickets by default (Makes it more Kanban like - not recommended for large datasets).
 
-``HELPDESK_TRANSLATE_TICKET_COMMENTS`` (default:``False``)
-  Show dropdown list of languages that ticket comments can be translated into via Google Translate?
+.. setting:: HELPDESK_KANBAN_DEFAULT_RENDER_CLOSED_TICKETS_WEEKS
 
-``HELPDESK_TRANSLATE_TICKET_COMMENTS_LANG`` (default:``["en", "de", "fr", "it", "ru"]``)
-  List of languages to offer. If set to false, all default google translate languages will be shown.
+   *Default:* ``6``
 
-``HELPDESK_FOLLOWUP_MOD`` (default:``False``)
-  Allow user to override default layout for 'followups' (work in progress)
+   Hides closed and duplicate tickets that have not been modified within this many weeks. Tickets with a ``Closed`` or ``Duplicate`` status whose ``modified`` timestamp is older than the cutoff are excluded from the board.
+   Set to ``0`` or ``None`` to always show all closed and duplicate tickets regardless of age.
 
-``HELPDESK_AUTO_SUBSCRIBE_ON_TICKET_RESPONSE`` (default:``False``)
-  Auto-subscribe user to ticket as a 'CC' if (s)he responds to a ticket?
+.. setting:: HELPDESK_KB_ENABLED
 
-``HELPDESK_EMAIL_SUBJECT_TEMPLATE`` (default: ``"{{ ticket.ticket }} {{ ticket.title|safe }} %(subject)s"``)
-  Subject template for templated emails. ``%(subject)s`` represents the subject wording from the email template (e.g. "(Closed)").
+   *Default:* ``True``
 
-  .. caution::
-     Your subject template should always include a ``{{ ticket.ticket }}`` somewhere as many ``django-helpdesk`` features rely on the ticket ID in the subject line in order to correctly route mail to the corresponding ticket. If you leave out the ticket ID, your helpdesk may not work correctly!
+   Show knowledgebase links?
 
+.. setting:: HELPDESK_NAVIGATION_ENABLED
 
-``HELPDESK_NOTIFY_SUBMITTER_FOR_ALL_TICKET_CHANGES`` (default:``False``)
-  Send email to submitter for all ticket updates. Default is to only sends to submitter for followups marked as public (defaults to True) on ticket creation, closing, status changes or followup comment.
+   *Default:* ``False``
 
+   Show extended navigation by default, to all users, irrespective of staff status?
 
-``HELPDESK_PRIVATE_FOLLOWUP_MEANS_NO_EMAILS`` (default: ``False``)
-  If ``True``, private follow-ups (marked with ``public=False``) will not trigger any email notifications to any recipients (submitters, assigned users, CC'd users, or queue notifications). This provides complete privacy for internal staff communications.
-  Public follow-ups (``public=True``) continue to work normally. This setting overrides other notification settings like ``HELPDESK_NOTIFY_SUBMITTER_FOR_ALL_TICKET_CHANGES`` when the follow-up is private.
+.. setting:: HELPDESK_SHOW_MY_TICKETS_IN_NAV_FOR_STAFF
 
-``HELPDESK_EMAIL_FALLBACK_LOCALE`` (default: ``en``)
-  Fallback locale for templated emails when queue locale not found
+   *Default:* ``True``
 
-``HELPDESK_MAX_EMAIL_ATTACHMENT_SIZE`` (default: ``512000``)
-  Maximum size, in bytes, of file attachments that will be sent via email
+   Show "My tickets" for staff. Typically used for help desk deployments that allow staff to create tickets to action other staff members.
 
-``QUEUE_EMAIL_BOX_UPDATE_ONLY`` (default: ``False``)
-  Only process mail with a valid tracking ID; all other mail will be ignored instead of creating a new ticket.
+.. setting:: HELPDESK_TRANSLATE_TICKET_COMMENTS
 
-``HELPDESK_ENABLE_DEPENDENCIES_ON_TICKET`` (default:``True``)
-  If False, disable the dependencies fields on ticket.
+   *Default:* ``False``
 
-``HELPDESK_ENABLE_TIME_SPENT_ON_TICKET`` (default: ``True``)
-  If False, disable the time spent fields on ticket.
+   Show dropdown list of languages that ticket comments can be translated into via Google Translate?
 
-``HELPDESK_TICKETS_TIMELINE_ENABLED`` (default: ``True``)
-  If False, remove from the dashboard the Timeline view for tickets.
+.. setting:: HELPDESK_TRANSLATE_TICKET_COMMENTS_LANG
+
+   *Default:* ``["en", "de", "fr", "it", "ru"]``
+
+   List of languages to offer. If set to false, all default google translate languages will be shown.
+
+.. setting:: HELPDESK_FOLLOWUP_MOD
+
+   *Default:* ``False``
+
+   Allow user to override default layout for 'followups' (work in progress)
+
+.. setting:: HELPDESK_AUTO_SUBSCRIBE_ON_TICKET_RESPONSE
+
+   *Default:* ``False``
+
+   Auto-subscribe user to ticket as a 'CC' if (s)he responds to a ticket?
+
+.. setting:: HELPDESK_EMAIL_SUBJECT_TEMPLATE
+
+   *Default:* ``"{{ ticket.ticket }} {{ ticket.title|safe }} %(subject)s"``
+
+   Subject template for templated emails. ``%(subject)s`` represents the subject wording from the email template (e.g. "(Closed)").
+
+   .. caution::
+      Your subject template should always include a ``{{ ticket.ticket }}`` somewhere as many ``django-helpdesk`` features rely on the ticket ID in the subject line in order to correctly route mail to the corresponding ticket. If you leave out the ticket ID, your helpdesk may not work correctly!
+
+.. setting:: HELPDESK_NOTIFY_SUBMITTER_FOR_ALL_TICKET_CHANGES
+
+   *Default:* ``False``
+
+   Send email to submitter for all ticket updates. Default is to only sends to submitter for followups marked as public (defaults to True) on ticket creation, closing, status changes or followup comment.
+
+.. setting:: HELPDESK_PRIVATE_FOLLOWUP_MEANS_NO_EMAILS
+
+   *Default:* ``False``
+
+   If ``True``, private follow-ups (marked with ``public=False``) will not trigger any email notifications to any recipients (submitters, assigned users, CC'd users, or queue notifications). This provides complete privacy for internal staff communications.
+   Public follow-ups (``public=True``) continue to work normally. This setting overrides other notification settings like :setting:`HELPDESK_NOTIFY_SUBMITTER_FOR_ALL_TICKET_CHANGES` when the follow-up is private.
+
+.. setting:: HELPDESK_EMAIL_FALLBACK_LOCALE
+
+   *Default:* ``en``
+
+   Fallback locale for templated emails when queue locale not found
+
+.. setting:: HELPDESK_MAX_EMAIL_ATTACHMENT_SIZE
+
+   *Default:* ``512000``
+
+   Maximum size, in bytes, of file attachments that will be sent via email
+
+.. setting:: QUEUE_EMAIL_BOX_UPDATE_ONLY
+
+   *Default:* ``False``
+
+   Only process mail with a valid tracking ID; all other mail will be ignored instead of creating a new ticket.
+
+.. setting:: HELPDESK_ENABLE_DEPENDENCIES_ON_TICKET
+
+   *Default:* ``True``
+
+   If False, disable the dependencies fields on ticket.
+
+.. setting:: HELPDESK_ENABLE_TIME_SPENT_ON_TICKET
+
+   *Default:* ``True``
+
+   If False, disable the time spent fields on ticket.
+
+.. setting:: HELPDESK_TICKETS_TIMELINE_ENABLED
+
+   *Default:* ``True``
+
+   If False, remove from the dashboard the Timeline view for tickets.
 
 
 Options shown on public pages
@@ -149,281 +226,366 @@ Options shown on public pages
 
 These options only change display of items on public-facing pages, not staff pages.
 
-``HELPDESK_VIEW_A_TICKET_PUBLIC`` (default:``True``)
-  Show 'View a Ticket' section on public page?
+.. setting:: HELPDESK_VIEW_A_TICKET_PUBLIC
 
-``HELPDESK_SUBMIT_A_TICKET_PUBLIC`` (default:``True``)
-  Show 'submit a ticket' section & form on public page?
+   *Default:* ``True``
 
-``HELPDESK_PUBLIC_TICKET_FORM_CLASS`` (default:``helpdesk.forms.PublicTicketForm``)
-  Define custom form class to show on public pages for anon users. You can use it for adding custom fields and validation, captcha and so on.
+   Show 'View a Ticket' section on public page?
+
+.. setting:: HELPDESK_SUBMIT_A_TICKET_PUBLIC
+
+   *Default:* ``True``
+
+   Show 'submit a ticket' section & form on public page?
+
+.. setting:: HELPDESK_PUBLIC_TICKET_FORM_CLASS
+
+   *Default:* ``helpdesk.forms.PublicTicketForm``
+
+   Define custom form class to show on public pages for anon users. You can use it for adding custom fields and validation, captcha and so on.
 
 
 Options for public ticket submission form
 -----------------------------------------
 
-``HELPDESK_PUBLIC_TICKET_QUEUE`` (default: Not defined)
-  Sets the queue for tickets submitted through the public form. If defined, the matching form field will be hidden. This cannot be `None` but must be set to a valid queue slug.
+.. setting:: HELPDESK_PUBLIC_TICKET_QUEUE
 
-``HELPDESK_PUBLIC_TICKET_PRIORITY`` (default: Not defined)
-  Sets the priority for tickets submitted through the public form. If defined, the matching form field will be hidden. Must be set to a valid integer priority.
+   *Default:* Not defined
 
-``HELPDESK_PUBLIC_TICKET_DUE_DATE`` (default: Not defined)
-  Sets the due date for tickets submitted through the public form. If defined, the matching form field will be hidden. Set to `None` if you want to hide the form field but do not want to define a value.
+   Sets the queue for tickets submitted through the public form. If defined, the matching form field will be hidden. This cannot be ``None`` but must be set to a valid queue slug.
 
+.. setting:: HELPDESK_PUBLIC_TICKET_PRIORITY
+
+   *Default:* Not defined
+
+   Sets the priority for tickets submitted through the public form. If defined, the matching form field will be hidden. Must be set to a valid integer priority.
+
+.. setting:: HELPDESK_PUBLIC_TICKET_DUE_DATE
+
+   *Default:* Not defined
+
+   Sets the due date for tickets submitted through the public form. If defined, the matching form field will be hidden. Set to ``None`` if you want to hide the form field but do not want to define a value.
 
 
 Options that change ticket updates
 ----------------------------------
 
-``HELPDESK_ALLOW_NON_STAFF_TICKET_UPDATE`` (default:``False``)
-  Allow non-staff users to interact with tickets?
-  Set to True to allow any authenticated user to manage tickets.
-  You can also apply a custom authorisation logic for identifying helpdesk staff members, by setting this to a callable.
-  In that case, the value should be a function accepting the active user as a parameter and returning True if the user is considered helpdesk staff, e.g.::
+.. setting:: HELPDESK_ALLOW_NON_STAFF_TICKET_UPDATE
 
-    lambda u: u.is_authenticated() and u.is_active and u.groups.filter(name='helpdesk_staff').exists()
+   *Default:* ``False``
 
-``HELPDESK_SHOW_EDIT_BUTTON_FOLLOW_UP`` (default:``True``)
-  Show edit buttons in ticket follow ups?
+   Allow non-staff users to interact with tickets?
+   Set to True to allow any authenticated user to manage tickets.
+   You can also apply a custom authorisation logic for identifying helpdesk staff members, by setting this to a callable.
+   In that case, the value should be a function accepting the active user as a parameter and returning True if the user is considered helpdesk staff, e.g.::
 
-``HELPDESK_SHOW_DELETE_BUTTON_SUPERUSER_FOLLOW_UP`` (default:``False``)
-  Show delete buttons in ticket follow ups if user is 'superuser'?
+     lambda u: u.is_authenticated() and u.is_active and u.groups.filter(name='helpdesk_staff').exists()
 
-``HELPDESK_UPDATE_PUBLIC_DEFAULT`` (default:``False``)
-  Make all updates public by default? This will hide the 'is this update public' checkbox.
+.. setting:: HELPDESK_SHOW_EDIT_BUTTON_FOLLOW_UP
 
-``HELPDESK_STAFF_ONLY_TICKET_OWNERS`` (default:``False``)
-  Only show staff users in ticket owner drop-downs?
+   *Default:* ``True``
 
-``HELPDESK_STAFF_ONLY_TICKET_CC`` (default:``False``)
-  Only show staff users in ticket cc drop-down?
+   Show edit buttons in ticket follow ups?
 
-``HELPDESK_SHOW_CUSTOM_FIELDS_FOLLOW_UP_LIST`` (default:``[]``)
-  Show configured custom fields in the follow-up form.
+.. setting:: HELPDESK_SHOW_DELETE_BUTTON_SUPERUSER_FOLLOW_UP
 
-``HELPDESK_FOLLOWUP_NEWEST_FIRST`` (default:``False``)
-  Sets the default order for the follow-up list on the ticket view. If True, the most recent follow up is listed first. If False, the oldest follow up is listed first. Users can still toggle the order from the ticket view using the sort button, regardless of this setting.
+   *Default:* ``False``
+
+   Show delete buttons in ticket follow ups if user is 'superuser'?
+
+.. setting:: HELPDESK_UPDATE_PUBLIC_DEFAULT
+
+   *Default:* ``False``
+
+   Make all updates public by default? This will hide the 'is this update public' checkbox.
+
+.. setting:: HELPDESK_STAFF_ONLY_TICKET_OWNERS
+
+   *Default:* ``False``
+
+   Only show staff users in ticket owner drop-downs?
+
+.. setting:: HELPDESK_STAFF_ONLY_TICKET_CC
+
+   *Default:* ``False``
+
+   Only show staff users in ticket cc drop-down?
+
+.. setting:: HELPDESK_SHOW_CUSTOM_FIELDS_FOLLOW_UP_LIST
+
+   *Default:* ``[]``
+
+   Show configured custom fields in the follow-up form.
+
+.. setting:: HELPDESK_FOLLOWUP_NEWEST_FIRST
+
+   *Default:* ``False``
+
+   Sets the default order for the follow-up list on the ticket view. If True, the most recent follow up is listed first. If False, the oldest follow up is listed first. Users can still toggle the order from the ticket view using the sort button, regardless of this setting.
+
 
 Options that change ticket properties
 -------------------------------------
 
-``HELPDESK_TICKET_OPEN_STATUS`` (default:``1``)
-  Customize the id of OPEN_STATUS status.
+.. setting:: HELPDESK_TICKET_OPEN_STATUS
 
-``HELPDESK_TICKET_REOPENED_STATUS`` (default:``2``)
-  Customize the id of REOPENED_STATUS status.
+   *Default:* ``1``
 
-``HELPDESK_TICKET_RESOLVED_STATUS`` (default:``3``)
-  Customize the id of RESOLVED_STATUS status.
+   Customize the id of OPEN_STATUS status.
 
-``HELPDESK_TICKET_CLOSED_STATUS`` (default: ``4``)
-  Customize the id of CLOSED_STATUS status.
+.. setting:: HELPDESK_TICKET_REOPENED_STATUS
 
-``HELPDESK_TICKET_DUPLICATE_STATUS`` (default: ``5``)
-  Customize the id of DUPLICATE_STATUS status.
+   *Default:* ``2``
 
-``HELPDESK_TICKET_STATUS_CHOICES``
-  Customize the list of status choices for all tickets.
+   Customize the id of REOPENED_STATUS status.
 
-  The ``default`` is::
+.. setting:: HELPDESK_TICKET_RESOLVED_STATUS
 
-    HELPDESK_TICKET_STATUS_CHOICES = (
-        (HELPDESK_TICKET_OPEN_STATUS, _('Open')),
-        (HELPDESK_TICKET_REOPENED_STATUS, _('Reopened')),
-        (HELPDESK_TICKET_RESOLVED_STATUS, _('Resolved')),
-        (HELPDESK_TICKET_CLOSED_STATUS, _('Closed')),
-        (HELPDESK_TICKET_DUPLICATE_STATUS, _('Duplicate')),
-    )
+   *Default:* ``3``
 
-  If you wish to modify or introduce new status choices, you may add them like this::
+   Customize the id of RESOLVED_STATUS status.
 
-    # Don't forget to import the gettext_lazy function at the begining of your settings file
-    from django.utils.translation import gettext_lazy as _
+.. setting:: HELPDESK_TICKET_CLOSED_STATUS
 
-    # Explicitly define status list integer values
-    HELPDESK_TICKET_OPEN_STATUS = 1
-    HELPDESK_TICKET_REOPENED_STATUS = 2
-    HELPDESK_TICKET_RESOLVED_STATUS = 3
-    HELPDESK_TICKET_CLOSED_STATUS = 4
-    HELPDESK_TICKET_DUPLICATE_STATUS = 5
-    HELPDESK_TICKET_FORKED_STATUS = 6
+   *Default:* ``4``
 
-    # Create the list with associated labels
-    HELPDESK_TICKET_STATUS_CHOICES = (
-        (HELPDESK_TICKET_OPEN_STATUS, _('Open')),
-        (HELPDESK_TICKET_REOPENED_STATUS, _('Reopened')),
-        (HELPDESK_TICKET_RESOLVED_STATUS, _('Resolved')),
-        (HELPDESK_TICKET_CLOSED_STATUS, _('Closed')),
-        (HELPDESK_TICKET_DUPLICATE_STATUS, _('Duplicate')),
-        (HELPDESK_TICKET_FORKED_STATUS, _('Forked')),
-    )
+   Customize the id of CLOSED_STATUS status.
 
-``HELPDESK_TICKET_OPEN_STATUSES``
-  (default: ``(HELPDESK_TICKET_OPEN_STATUS, HELPDESK_TICKET_REOPENED_STATUS)``)
+.. setting:: HELPDESK_TICKET_DUPLICATE_STATUS
 
-  Define the list of statuses to be considered as a type of open status.
+   *Default:* ``5``
 
-  If you have added the ``HELPDESK_TICKET_FORKED_STATUS`` status and wish to have django-helpdesk treat it as an open status choice, add it to the list of OPEN_STATUSES like this::
+   Customize the id of DUPLICATE_STATUS status.
 
-    HELPDESK_TICKET_OPEN_STATUSES = (HELPDESK_TICKET_OPEN_STATUS,
-                                     HELPDESK_TICKET_REOPENED_STATUS,
-                                     HELPDESK_TICKET_FORKED_STATUS)
+.. setting:: HELPDESK_TICKET_STATUS_CHOICES
 
-``HELPDESK_TICKET_STATUS_CHOICES_FLOW``
-  Customize the allowed state changes depending on the current state.
+   Customize the list of status choices for all tickets.
 
-  The default is::
+   The ``default`` is::
 
-    HELPDESK_TICKET_STATUS_CHOICES_FLOW = {
-        HELPDESK_TICKET_OPEN_STATUS: (HELPDESK_TICKET_OPEN_STATUS, HELPDESK_TICKET_RESOLVED_STATUS, HELPDESK_TICKET_CLOSED_STATUS, HELPDESK_TICKET_DUPLICATE_STATUS,),
-        HELPDESK_TICKET_REOPENED_STATUS: (HELPDESK_TICKET_REOPENED_STATUS, HELPDESK_TICKET_RESOLVED_STATUS, HELPDESK_TICKET_CLOSED_STATUS, HELPDESK_TICKET_DUPLICATE_STATUS,),
-        HELPDESK_TICKET_RESOLVED_STATUS: (HELPDESK_TICKET_REOPENED_STATUS, HELPDESK_TICKET_RESOLVED_STATUS, HELPDESK_TICKET_CLOSED_STATUS,),
-        HELPDESK_TICKET_CLOSED_STATUS: (HELPDESK_TICKET_REOPENED_STATUS, HELPDESK_TICKET_CLOSED_STATUS,),
-        HELPDESK_TICKET_DUPLICATE_STATUS: (HELPDESK_TICKET_REOPENED_STATUS, HELPDESK_TICKET_DUPLICATE_STATUS,),
-    }
+     HELPDESK_TICKET_STATUS_CHOICES = (
+         (HELPDESK_TICKET_OPEN_STATUS, _('Open')),
+         (HELPDESK_TICKET_REOPENED_STATUS, _('Reopened')),
+         (HELPDESK_TICKET_RESOLVED_STATUS, _('Resolved')),
+         (HELPDESK_TICKET_CLOSED_STATUS, _('Closed')),
+         (HELPDESK_TICKET_DUPLICATE_STATUS, _('Duplicate')),
+     )
 
-  If you wish to modify or have introduce new status choices, you may configure their status change flow like this::
+   If you wish to modify or introduce new status choices, you may add them like this::
 
-    # Adding HELPDESK_TICKET_FORKED_STATUS to the other allowed states flow and defining its own flow
-    HELPDESK_TICKET_STATUS_CHOICES_FLOW = {
-        HELPDESK_TICKET_OPEN_STATUS: (HELPDESK_TICKET_OPEN_STATUS, HELPDESK_TICKET_FORKED_STATUS, HELPDESK_TICKET_RESOLVED_STATUS, HELPDESK_TICKET_CLOSED_STATUS, HELPDESK_TICKET_DUPLICATE_STATUS,),
-        HELPDESK_TICKET_REOPENED_STATUS: (HELPDESK_TICKET_REOPENED_STATUS, HELPDESK_TICKET_FORKED_STATUS, HELPDESK_TICKET_RESOLVED_STATUS, HELPDESK_TICKET_CLOSED_STATUS, HELPDESK_TICKET_DUPLICATE_STATUS,),
-        HELPDESK_TICKET_RESOLVED_STATUS: (HELPDESK_TICKET_REOPENED_STATUS, HELPDESK_TICKET_RESOLVED_STATUS, HELPDESK_TICKET_CLOSED_STATUS,),
-        HELPDESK_TICKET_CLOSED_STATUS: (HELPDESK_TICKET_REOPENED_STATUS, HELPDESK_TICKET_CLOSED_STATUS,),
-        HELPDESK_TICKET_DUPLICATE_STATUS: (HELPDESK_TICKET_REOPENED_STATUS, HELPDESK_TICKET_DUPLICATE_STATUS,),
-        HELPDESK_TICKET_FORKED_STATUS: (HELPDESK_TICKET_OPEN_STATUS, HELPDESK_TICKET_FORKED_STATUS, HELPDESK_TICKET_RESOLVED_STATUS, HELPDESK_TICKET_CLOSED_STATUS, HELPDESK_TICKET_DUPLICATE_STATUS,),
-    }
+     # Don't forget to import the gettext_lazy function at the begining of your settings file
+     from django.utils.translation import gettext_lazy as _
 
-``HELPDESK_TICKET_STATUS_CSS_CLASSES``
-  Customize the Bootstrap CSS class used for the status badge of each ticket in the ticket list.
+     # Explicitly define status list integer values
+     HELPDESK_TICKET_OPEN_STATUS = 1
+     HELPDESK_TICKET_REOPENED_STATUS = 2
+     HELPDESK_TICKET_RESOLVED_STATUS = 3
+     HELPDESK_TICKET_CLOSED_STATUS = 4
+     HELPDESK_TICKET_DUPLICATE_STATUS = 5
+     HELPDESK_TICKET_FORKED_STATUS = 6
 
-  The default is::
+     # Create the list with associated labels
+     HELPDESK_TICKET_STATUS_CHOICES = (
+         (HELPDESK_TICKET_OPEN_STATUS, _('Open')),
+         (HELPDESK_TICKET_REOPENED_STATUS, _('Reopened')),
+         (HELPDESK_TICKET_RESOLVED_STATUS, _('Resolved')),
+         (HELPDESK_TICKET_CLOSED_STATUS, _('Closed')),
+         (HELPDESK_TICKET_DUPLICATE_STATUS, _('Duplicate')),
+         (HELPDESK_TICKET_FORKED_STATUS, _('Forked')),
+     )
 
-    HELPDESK_TICKET_STATUS_CSS_CLASSES = {
-        HELPDESK_TICKET_OPEN_STATUS: 'danger',
-        HELPDESK_TICKET_REOPENED_STATUS: 'warning',
-        HELPDESK_TICKET_RESOLVED_STATUS: 'success',
-        HELPDESK_TICKET_CLOSED_STATUS: 'success',
-        HELPDESK_TICKET_DUPLICATE_STATUS: 'secondary',
-    }
+.. setting:: HELPDESK_TICKET_OPEN_STATUSES
 
-  Statuses not present in the map return an empty string from the model; the
-  ticket-list template applies ``secondary`` (gray) as the default when the
-  class is empty. To give a custom status its own badge color, add an entry like this::
+   *Default:* ``(HELPDESK_TICKET_OPEN_STATUS, HELPDESK_TICKET_REOPENED_STATUS)``
 
-    HELPDESK_TICKET_STATUS_CSS_CLASSES = {
-        HELPDESK_TICKET_OPEN_STATUS: 'danger',
-        HELPDESK_TICKET_REOPENED_STATUS: 'warning',
-        HELPDESK_TICKET_RESOLVED_STATUS: 'success',
-        HELPDESK_TICKET_CLOSED_STATUS: 'success',
-        HELPDESK_TICKET_DUPLICATE_STATUS: 'secondary',
-        HELPDESK_TICKET_FORKED_STATUS: 'dark',
-    }
+   Define the list of statuses to be considered as a type of open status.
 
-``HELPDESK_TICKET_PRIORITY_CHOICES``
-  Customize the priority choices for all tickets.
+   If you have added the ``HELPDESK_TICKET_FORKED_STATUS`` status and wish to have django-helpdesk treat it as an open status choice, add it to the list of OPEN_STATUSES like this::
 
-  The default is::
+     HELPDESK_TICKET_OPEN_STATUSES = (HELPDESK_TICKET_OPEN_STATUS,
+                                      HELPDESK_TICKET_REOPENED_STATUS,
+                                      HELPDESK_TICKET_FORKED_STATUS)
 
-    HELPDESK_TICKET_PRIORITY_CHOICES = (
-        (1, _('1. Critical')),
-        (2, _('2. High')),
-        (3, _('3. Normal')),
-        (4, _('4. Low')),
-        (5, _('5. Very Low')),
-    )
+.. setting:: HELPDESK_TICKET_STATUS_CHOICES_FLOW
 
-  If you have a new instance, you may override those settings but if you want to keep previous tickets priorities and add new choices, you may increment integer values like this::
+   Customize the allowed state changes depending on the current state.
 
-    HELPDESK_TICKET_PRIORITY_CHOICES = (
-        (1, _('1. Critical')),
-        (2, _('2. High')),
-        (3, _('3. Normal')),
-        (4, _('4. Low')),
-        (5, _('5. Very Low')),
-        (6, _('6. Cold')),
-        (7, _('7. Hot')),
-    )
+   The default is::
 
-``HELPDESK_TICKET_PRIORITY_CSS_CLASSES``
-  Customize the Bootstrap CSS class used for the priority badge of each ticket in the ticket list.
+     HELPDESK_TICKET_STATUS_CHOICES_FLOW = {
+         HELPDESK_TICKET_OPEN_STATUS: (HELPDESK_TICKET_OPEN_STATUS, HELPDESK_TICKET_RESOLVED_STATUS, HELPDESK_TICKET_CLOSED_STATUS, HELPDESK_TICKET_DUPLICATE_STATUS,),
+         HELPDESK_TICKET_REOPENED_STATUS: (HELPDESK_TICKET_REOPENED_STATUS, HELPDESK_TICKET_RESOLVED_STATUS, HELPDESK_TICKET_CLOSED_STATUS, HELPDESK_TICKET_DUPLICATE_STATUS,),
+         HELPDESK_TICKET_RESOLVED_STATUS: (HELPDESK_TICKET_REOPENED_STATUS, HELPDESK_TICKET_RESOLVED_STATUS, HELPDESK_TICKET_CLOSED_STATUS,),
+         HELPDESK_TICKET_CLOSED_STATUS: (HELPDESK_TICKET_REOPENED_STATUS, HELPDESK_TICKET_CLOSED_STATUS,),
+         HELPDESK_TICKET_DUPLICATE_STATUS: (HELPDESK_TICKET_REOPENED_STATUS, HELPDESK_TICKET_DUPLICATE_STATUS,),
+     }
 
-  The default is::
+   If you wish to modify or have introduce new status choices, you may configure their status change flow like this::
 
-    HELPDESK_TICKET_PRIORITY_CSS_CLASSES = {
-        1: 'danger',
-        2: 'warning',
-        3: 'success',
-        4: 'info',
-        5: 'secondary',
-    }
+     # Adding HELPDESK_TICKET_FORKED_STATUS to the other allowed states flow and defining its own flow
+     HELPDESK_TICKET_STATUS_CHOICES_FLOW = {
+         HELPDESK_TICKET_OPEN_STATUS: (HELPDESK_TICKET_OPEN_STATUS, HELPDESK_TICKET_FORKED_STATUS, HELPDESK_TICKET_RESOLVED_STATUS, HELPDESK_TICKET_CLOSED_STATUS, HELPDESK_TICKET_DUPLICATE_STATUS,),
+         HELPDESK_TICKET_REOPENED_STATUS: (HELPDESK_TICKET_REOPENED_STATUS, HELPDESK_TICKET_FORKED_STATUS, HELPDESK_TICKET_RESOLVED_STATUS, HELPDESK_TICKET_CLOSED_STATUS, HELPDESK_TICKET_DUPLICATE_STATUS,),
+         HELPDESK_TICKET_RESOLVED_STATUS: (HELPDESK_TICKET_REOPENED_STATUS, HELPDESK_TICKET_RESOLVED_STATUS, HELPDESK_TICKET_CLOSED_STATUS,),
+         HELPDESK_TICKET_CLOSED_STATUS: (HELPDESK_TICKET_REOPENED_STATUS, HELPDESK_TICKET_CLOSED_STATUS,),
+         HELPDESK_TICKET_DUPLICATE_STATUS: (HELPDESK_TICKET_REOPENED_STATUS, HELPDESK_TICKET_DUPLICATE_STATUS,),
+         HELPDESK_TICKET_FORKED_STATUS: (HELPDESK_TICKET_OPEN_STATUS, HELPDESK_TICKET_FORKED_STATUS, HELPDESK_TICKET_RESOLVED_STATUS, HELPDESK_TICKET_CLOSED_STATUS, HELPDESK_TICKET_DUPLICATE_STATUS,),
+     }
 
-  Priorities not present in the map return an empty string from the model; the
-  ticket-list template applies ``secondary`` (gray) as the default when the
-  class is empty.
+.. setting:: HELPDESK_TICKET_STATUS_CSS_CLASSES
+
+   Customize the Bootstrap CSS class used for the status badge of each ticket in the ticket list.
+
+   The default is::
+
+     HELPDESK_TICKET_STATUS_CSS_CLASSES = {
+         HELPDESK_TICKET_OPEN_STATUS: 'danger',
+         HELPDESK_TICKET_REOPENED_STATUS: 'warning',
+         HELPDESK_TICKET_RESOLVED_STATUS: 'success',
+         HELPDESK_TICKET_CLOSED_STATUS: 'success',
+         HELPDESK_TICKET_DUPLICATE_STATUS: 'secondary',
+     }
+
+   Statuses not present in the map return an empty string from the model; the
+   ticket-list template applies ``secondary`` (gray) as the default when the
+   class is empty. To give a custom status its own badge color, add an entry like this::
+
+     HELPDESK_TICKET_STATUS_CSS_CLASSES = {
+         HELPDESK_TICKET_OPEN_STATUS: 'danger',
+         HELPDESK_TICKET_REOPENED_STATUS: 'warning',
+         HELPDESK_TICKET_RESOLVED_STATUS: 'success',
+         HELPDESK_TICKET_CLOSED_STATUS: 'success',
+         HELPDESK_TICKET_DUPLICATE_STATUS: 'secondary',
+         HELPDESK_TICKET_FORKED_STATUS: 'dark',
+     }
+
+.. setting:: HELPDESK_TICKET_PRIORITY_CHOICES
+
+   Customize the priority choices for all tickets.
+
+   The default is::
+
+     HELPDESK_TICKET_PRIORITY_CHOICES = (
+         (1, _('1. Critical')),
+         (2, _('2. High')),
+         (3, _('3. Normal')),
+         (4, _('4. Low')),
+         (5, _('5. Very Low')),
+     )
+
+   If you have a new instance, you may override those settings but if you want to keep previous tickets priorities and add new choices, you may increment integer values like this::
+
+     HELPDESK_TICKET_PRIORITY_CHOICES = (
+         (1, _('1. Critical')),
+         (2, _('2. High')),
+         (3, _('3. Normal')),
+         (4, _('4. Low')),
+         (5, _('5. Very Low')),
+         (6, _('6. Cold')),
+         (7, _('7. Hot')),
+     )
+
+.. setting:: HELPDESK_TICKET_PRIORITY_CSS_CLASSES
+
+   Customize the Bootstrap CSS class used for the priority badge of each ticket in the ticket list.
+
+   The default is::
+
+     HELPDESK_TICKET_PRIORITY_CSS_CLASSES = {
+         1: 'danger',
+         2: 'warning',
+         3: 'success',
+         4: 'info',
+         5: 'secondary',
+     }
+
+   Priorities not present in the map return an empty string from the model; the
+   ticket-list template applies ``secondary`` (gray) as the default when the
+   class is empty.
 
 
 Time Tracking Options
 ---------------------
 
-``HELPDESK_FOLLOWUP_TIME_SPENT_AUTO`` (default:``False``)
-  If ``True``, calculate follow-up 'time_spent' with previous follow-up or ticket creation time.
+.. setting:: HELPDESK_FOLLOWUP_TIME_SPENT_AUTO
 
-``HELPDESK_FOLLOWUP_TIME_SPENT_OPENING_HOURS`` (default:``{}``)
-  If defined, calculates follow-up 'time_spent' according to open hours.
+   *Default:* ``False``
 
-  If ``HELPDESK_FOLLOWUP_TIME_SPENT_AUTO=True``, you may set open hours to remove off hours from 'time_spent'::
+   If ``True``, calculate follow-up 'time_spent' with previous follow-up or ticket creation time.
 
-    HELPDESK_FOLLOWUP_TIME_SPENT_OPENING_HOURS = {
-        "monday": (8.5, 19),
-        "tuesday": (8.5, 19),
-        "wednesday": (8.5, 19),
-        "thursday": (8.5, 19),
-        "friday": (8.5, 19),
-        "saturday": (0, 0),
-        "sunday": (0, 0),
-    }
+.. setting:: HELPDESK_FOLLOWUP_TIME_SPENT_OPENING_HOURS
 
-  Valid hour values must be set between 0 and 23.9999.
-  In this example 8.5 is interpreted as 8:30AM, saturdays and sundays don't count.
+   *Default:* ``{}``
 
-``HELPDESK_FOLLOWUP_TIME_SPENT_EXCLUDE_HOLIDAYS`` (default: ``()``)
-  List of days in format ``%Y-%m-%d`` to exclude from automatic follow-up 'time_spent' calculation.
+   If defined, calculates follow-up 'time_spent' according to open hours.
 
-  This example removes Christmas and New Year's Eve in 2024::
+   If ``HELPDESK_FOLLOWUP_TIME_SPENT_AUTO=True``, you may set open hours to remove off hours from 'time_spent'::
 
-    HELPDESK_FOLLOWUP_TIME_SPENT_EXCLUDE_HOLIDAYS = ("2024-12-25", "2024-12-31",)
+     HELPDESK_FOLLOWUP_TIME_SPENT_OPENING_HOURS = {
+         "monday": (8.5, 19),
+         "tuesday": (8.5, 19),
+         "wednesday": (8.5, 19),
+         "thursday": (8.5, 19),
+         "friday": (8.5, 19),
+         "saturday": (0, 0),
+         "sunday": (0, 0),
+     }
 
-``HELPDESK_FOLLOWUP_TIME_SPENT_EXCLUDE_STATUSES`` (default: ``()``)
-  List of ticket statuses to exclude from automatic follow-up 'time_spent' calculation.
+   Valid hour values must be set between 0 and 23.9999.
+   In this example 8.5 is interpreted as 8:30AM, saturdays and sundays don't count.
 
-  This example will have follow-ups to resolved ticket status not to be counted in::
+.. setting:: HELPDESK_FOLLOWUP_TIME_SPENT_EXCLUDE_HOLIDAYS
 
-    HELPDESK_FOLLOWUP_TIME_SPENT_EXCLUDE_STATUSES = (HELPDESK_TICKET_RESOLVED_STATUS,)
+   *Default:* ``()``
 
-``HELPDESK_FOLLOWUP_TIME_SPENT_EXCLUDE_QUEUES`` (default: ``()``)
-  List of ticket queues slugs to exclude from automatic follow-up 'time_spent' calculation.
+   List of days in format ``%Y-%m-%d`` to exclude from automatic follow-up 'time_spent' calculation.
 
-  This example will have follow-ups excluded from time calculation if they belong to the queue with slug ``time-not-counting-queue``::
+   This example removes Christmas and New Year's Eve in 2024::
 
-    HELPDESK_FOLLOWUP_TIME_SPENT_EXCLUDE_QUEUES = ('time-not-counting-queue',)
+     HELPDESK_FOLLOWUP_TIME_SPENT_EXCLUDE_HOLIDAYS = ("2024-12-25", "2024-12-31",)
+
+.. setting:: HELPDESK_FOLLOWUP_TIME_SPENT_EXCLUDE_STATUSES
+
+   *Default:* ``()``
+
+   List of ticket statuses to exclude from automatic follow-up 'time_spent' calculation.
+
+   This example will have follow-ups to resolved ticket status not to be counted in::
+
+     HELPDESK_FOLLOWUP_TIME_SPENT_EXCLUDE_STATUSES = (HELPDESK_TICKET_RESOLVED_STATUS,)
+
+.. setting:: HELPDESK_FOLLOWUP_TIME_SPENT_EXCLUDE_QUEUES
+
+   *Default:* ``()``
+
+   List of ticket queues slugs to exclude from automatic follow-up 'time_spent' calculation.
+
+   This example will have follow-ups excluded from time calculation if they belong to the queue with slug ``time-not-counting-queue``::
+
+     HELPDESK_FOLLOWUP_TIME_SPENT_EXCLUDE_QUEUES = ('time-not-counting-queue',)
 
 
 Staff Ticket Creation Settings
 ------------------------------
 
-``HELPDESK_CREATE_TICKET_HIDE_ASSIGNED_TO`` (default:``False``)
-  Hide the 'assigned to' / 'Case owner' field from the 'create_ticket' view? It'll still show on the ticket detail/edit form.
+.. setting:: HELPDESK_CREATE_TICKET_HIDE_ASSIGNED_TO
+
+   *Default:* ``False``
+
+   Hide the 'assigned to' / 'Case owner' field from the 'create_ticket' view? It'll still show on the ticket detail/edit form.
+
 
 Staff Ticket View Settings
 ------------------------------
 
-``HELPDESK_ENABLE_PER_QUEUE_STAFF_PERMISSION`` (default:``False``)
-  If ``True``, logged in staff users only see queues and tickets to which they have specifically been granted access -  this holds for the dashboard, ticket query, and ticket report views. User assignment is done through the standard ``django.admin.admin`` permissions.
+.. setting:: HELPDESK_ENABLE_PER_QUEUE_STAFF_PERMISSION
 
-  .. note::
-     Staff with access to admin interface will be able to see the full list of tickets, but won't have access to details and could not modify them. This setting does not prevent staff users from creating tickets for all queues. Also, superuser accounts have full access to all queues, regardless of whatever queue memberships they have been granted.
+   *Default:* ``False``
+
+   If ``True``, logged in staff users only see queues and tickets to which they have specifically been granted access -  this holds for the dashboard, ticket query, and ticket report views. User assignment is done through the standard ``django.admin.admin`` permissions.
+
+   .. note::
+      Staff with access to admin interface will be able to see the full list of tickets, but won't have access to details and could not modify them. This setting does not prevent staff users from creating tickets for all queues. Also, superuser accounts have full access to all queues, regardless of whatever queue memberships they have been granted.
 
 
 Default E-Mail Settings
@@ -431,86 +593,105 @@ Default E-Mail Settings
 
 The following settings default to ``None`` but can be set as defaults, rather than setting them per-queue.
 
-``QUEUE_EMAIL_BOX_TYPE``
-  Protocol used: ``pop3``, ``imap`` or ``oauth``.
+.. setting:: QUEUE_EMAIL_BOX_TYPE
 
-``QUEUE_EMAIL_BOX_SSL``
-  Set to ``True`` to use SSL, otherwise ``False``.
+   Protocol used: ``pop3``, ``imap`` or ``oauth``.
 
-``QUEUE_EMAIL_BOX_HOST``
-  The URL of the mail server.
+.. setting:: QUEUE_EMAIL_BOX_SSL
 
-``QUEUE_EMAIL_BOX_USER``
-  The ``username`` of the email account.
+   Set to ``True`` to use SSL, otherwise ``False``.
 
-``QUEUE_EMAIL_BOX_PASSWORD``
-  The ``password`` of the email account.
+.. setting:: QUEUE_EMAIL_BOX_HOST
 
-  If ``oauth`` is used, configure ``HELPDESK_OAUTH``::
+   The URL of the mail server.
 
-    HELPDESK_OAUTH = {
-        "token_url": "",
-        "client_id": "",
-        "secret": "",
-        "scope": [""],
-    }
+.. setting:: QUEUE_EMAIL_BOX_USER
 
-``HELPDESK_IMAP_DEBUG_LEVEL`` (default: ``0``)
-  If using ``imap`` or ``oauth``, set the IMAP debug logging level. Default: ``0`` (no debugging).
+   The ``username`` of the email account.
+
+.. setting:: QUEUE_EMAIL_BOX_PASSWORD
+
+   The ``password`` of the email account.
+
+   If ``oauth`` is used, configure ``HELPDESK_OAUTH``::
+
+     HELPDESK_OAUTH = {
+         "token_url": "",
+         "client_id": "",
+         "secret": "",
+         "scope": [""],
+     }
+
+.. setting:: HELPDESK_IMAP_DEBUG_LEVEL
+
+   *Default:* ``0``
+
+   If using ``imap`` or ``oauth``, set the IMAP debug logging level. Default: ``0`` (no debugging).
 
 
 Discontinued Settings
 ---------------------
 The following settings were defined in previous versions and are no longer supported.
 
-``HELPDESK_CUSTOM_WELCOME``
+.. setting:: HELPDESK_CUSTOM_WELCOME
 
-``HELDPESK_KB_ENABLED_STAFF``
-  Now always True
+.. setting:: HELDPESK_KB_ENABLED_STAFF
 
-``HELPDESK_NAVIGATION_STATS_ENABLED``
-  Now always True
+   Now always True
 
-``HELPDESK_PREPEND_ORG_NAME``
-  Please customise your local ``helpdesk/base.html`` template if needed
+.. setting:: HELPDESK_NAVIGATION_STATS_ENABLED
 
-``HELPDESK_SHOW_DELETE_BUTTON_TICKET_TOP``
-  Button is always shown
+   Now always True
 
-``HELPDESK_SHOW_EDIT_BUTTON_TICKET_TOP``
-  Button is always shown
+.. setting:: HELPDESK_PREPEND_ORG_NAME
 
-``HELPDESK_SHOW_HOLD_BUTTON_TICKET_TOP``
-  Button is always shown
+   Please customise your local ``helpdesk/base.html`` template if needed
 
-``HELPDESK_SHOW_KB_ON_HOMEPAGE``
-  KB categories are always shown on the homepage
+.. setting:: HELPDESK_SHOW_DELETE_BUTTON_TICKET_TOP
 
-``HELPDESK_SUPPORT_PERSON``
-  Please customise your local ``helpdesk/attribution.html`` template if needed
+   Button is always shown
 
-``HELPDESK_DASHBOARD_SHOW_DELETE_UNASSIGNED``
-  Button is always shown
+.. setting:: HELPDESK_SHOW_EDIT_BUTTON_TICKET_TOP
 
-``HELPDESK_DASHBOARD_HIDE_EMPTY_QUEUES``
-  Empty queues are always hidden
+   Button is always shown
 
-``HELPDESK_DASHBOARD_BASIC_TICKET_STATS``
-  Stats are always shown
+.. setting:: HELPDESK_SHOW_HOLD_BUTTON_TICKET_TOP
 
-``HELPDESK_FOOTER_SHOW_API_LINK``
-  Link to API documentation is always shown. Edit your local ``helpdesk/base.html`` template if needed.
+   Button is always shown
 
-``HELPDESK_FOOTER_SHOW_CHANGE_LANGUAGE_LINK``
-  Is never shown. Use your own template if required.
+.. setting:: HELPDESK_SHOW_KB_ON_HOMEPAGE
 
-``HELPDESK_ENABLE_PER_QUEUE_MEMBERSHIP``
-  Discontinued in favor of ``HELPDESK_ENABLE_PER_QUEUE_STAFF_PERMISSION``.
+   KB categories are always shown on the homepage
 
-``HELPDESK_FULL_FIRST_MESSAGE_FROM_EMAIL``
-  Do not ignore fowarded and replied text from the email messages which create a new ticket; useful for cases when customer forwards some email (error from service or something) and wants support to see that
+.. setting:: HELPDESK_SUPPORT_PERSON
 
-``HELPDESK_ALWAYS_SAVE_INCOMING_EMAIL_MESSAGE``
-  Any incoming .eml message is saved and available, helps when customer spent some time doing fancy markup which has been corrupted during the ``email-to-ticket-comment`` translate process.
+   Please customise your local ``helpdesk/attribution.html`` template if needed
 
-  Requires ``HELPDESK_ENABLE_ATTACHMENTS`` to be set to ``True``
+.. setting:: HELPDESK_DASHBOARD_SHOW_DELETE_UNASSIGNED
+
+   Button is always shown
+
+.. setting:: HELPDESK_DASHBOARD_HIDE_EMPTY_QUEUES
+
+   Empty queues are always hidden
+
+.. setting:: HELPDESK_DASHBOARD_BASIC_TICKET_STATS
+
+   Stats are always shown
+
+.. setting:: HELPDESK_FOOTER_SHOW_API_LINK
+
+   Link to API documentation is always shown. Edit your local ``helpdesk/base.html`` template if needed.
+
+.. setting:: HELPDESK_FOOTER_SHOW_CHANGE_LANGUAGE_LINK
+
+   Is never shown. Use your own template if required.
+
+.. setting:: HELPDESK_ENABLE_PER_QUEUE_MEMBERSHIP
+
+   Discontinued in favor of :setting:`HELPDESK_ENABLE_PER_QUEUE_STAFF_PERMISSION`.
+
+.. setting:: HELPDESK_FULL_FIRST_MESSAGE_FROM_EMAIL
+
+   Do not ignore fowarded and replied text from the email messages which create a new ticket; useful for cases when customer forwards some email (error from service or something) and wants support to see that
+

--- a/docs/standalone.rst
+++ b/docs/standalone.rst
@@ -215,7 +215,7 @@ S3 base attachment support
 
 You will need to use the standalone-extras image for S3 support.
 
-Working from the previous SES example we add the following to `local_settings`:
+Working from the previous SES example we add the following to ``local_settings``:
 
 .. code-block:: python
 


### PR DESCRIPTION
Stacked on #1414, so the diff to review is the second commit only. The base needs to move to `main` once #1414 lands.

The reference pages were plain definition lists, so no individual setting had an anchor. There was no way to link anyone to `HELPDESK_ENABLE_ATTACHMENTS`, and a setting name mentioned in prose was just literal text that nothing checked.

## A `setting` object type

`docs/conf.py` registers one through `add_object_type`, which is the built-in shortcut for what Django's own documentation does with a full custom domain:

```python
def setup(app):
    app.add_object_type(
        "setting",
        "setting",
        objname="django-helpdesk setting",
        indextemplate="pair: %s; setting",
    )
```

The Python domain's `py:data` would have worked too, and was the first thing I tried. I moved away from it because these are not attributes of any module we ship. They live in the deployer's own `settings.py`, and putting them in the `py` inventory would mix them into the Python index the day we add autodoc for the models.

The 81 entries in `docs/settings.rst` become `setting` directives, each with an anchor, a permalink and an index entry, and `` :setting:`NAME` `` now resolves to them. Five mentions in prose became cross-references. The default value moves out of the term and into the body, so it no longer has to be squeezed into the heading:

```rst
.. setting:: HELPDESK_KANBAN_ENABLED

   *Default:* ``True``

   Show the Kanban board?
```

You can see the result here : https://django-helpdesk--1415.org.readthedocs.build/en/1415/settings.html

The tables in `docs/standalone.rst` were deliberately left as they are. They document the Docker image's environment variables, which are a separate namespace, and two of the names listed there are not settings at all.

## Management commands

The three commands the configuration walkthrough tells you to run are now documented with `program` and `option` directives, their flags taken from each command's `add_arguments` rather than from the surrounding prose. `--debug_to_stdout` and `--notify-only` are now cross-references from the walkthrough.

The `--debug_to_stdout` example was wrapped in `**` inside a literal block, so the asterisks were rendering verbatim. Fixed.

## One setting was in the wrong section

`HELPDESK_ALWAYS_SAVE_INCOMING_EMAIL_MESSAGE` was listed under Discontinued Settings, but `src/helpdesk/settings.py` still reads it and `src/helpdesk/email.py` still acts on it, gated on `HELPDESK_ENABLE_ATTACHMENTS` exactly as its description claims. It moves back up with the other attachment settings. It is the only one of the seventeen names in that section that still exists in the code, the other sixteen are genuinely gone.

## Also

Single backticks that were rendering as italics rather than as literals, in `api.rst`, `install.rst`, `standalone.rst` and `settings.rst`. I chose this over setting `default_role = "literal"`, to avoid changing a Sphinx default for six occurrences.

The `epub_exclude_files` change is carried here as well: the EPUB builder never references the logo files, and with `fail_on_warning: true` the two unknown-MIME-type warnings were failing the Read the Docs build.

## Verification

`sphinx-build -W` clean for `html`, `epub` and `latex`, since `.readthedocs.yaml` sets `formats: all` with `fail_on_warning: true`.

Draft for now: I would like to see it rendered on Read the Docs before calling it done.
## Deliberately not here

`HELPDESK_PUBLIC_ENABLED` is set by the standalone and demo configs and promised by `docs/standalone.rst`, but nothing in django-helpdesk reads it. Documenting it in `docs/settings.rst` would promise the dead switch a second time, so the question is in #1416 instead.
