### PR TITLE
Fix typos in Python and RST files

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -33,7 +33,7 @@ You need to provide a JSON body with the following data
     The description of the ticket
 
 ``resolution``
-    An optional text for the resoltuion of the ticket
+    An optional text for the resolution of the ticket
 
 ``submitter_email``
     The email of the ticket submitter

--- a/docs/custom_templates.rst
+++ b/docs/custom_templates.rst
@@ -5,7 +5,7 @@ django-helpdesk supports custom HTML templates that can be styled with CSS.
 
 In particular, users can include a file named ``helpdesk-customize.css`` in their django project directory to provide CSS overrides easily.
 
-In general, entire HTML and CSS templates may be overriden by including a file of the same name in the project directory. Django automatically searches the project directory before searching for default templates included with django-helpdesk.
+In general, entire HTML and CSS templates may be overridden by including a file of the same name in the project directory. Django automatically searches the project directory before searching for default templates included with django-helpdesk.
 
 Follow-up colors
 -----------------

--- a/docs/iframe_submission.rst
+++ b/docs/iframe_submission.rst
@@ -1,4 +1,4 @@
-Ticket submission with embeded iframe
+Ticket submission with embedded iframe
 =====================================
 
 Django-helpdesk associates an email address with each submitted ticket.

--- a/docs/iframe_submission.rst
+++ b/docs/iframe_submission.rst
@@ -1,5 +1,5 @@
 Ticket submission with embedded iframe
-=====================================
+======================================
 
 Django-helpdesk associates an email address with each submitted ticket.
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -373,7 +373,7 @@ Options that change ticket properties
 
    If you wish to modify or introduce new status choices, you may add them like this::
 
-     # Don't forget to import the gettext_lazy function at the begining of your settings file
+     # Don't forget to import the gettext_lazy function at the beginning of your settings file
      from django.utils.translation import gettext_lazy as _
 
      # Explicitly define status list integer values
@@ -693,5 +693,5 @@ The following settings were defined in previous versions and are no longer suppo
 
 .. setting:: HELPDESK_FULL_FIRST_MESSAGE_FROM_EMAIL
 
-   Do not ignore fowarded and replied text from the email messages which create a new ticket; useful for cases when customer forwards some email (error from service or something) and wants support to see that
+   Do not ignore forwarded and replied text from the email messages which create a new ticket; useful for cases when customer forwards some email (error from service or something) and wants support to see that
 

--- a/docs/webhooks.rst
+++ b/docs/webhooks.rst
@@ -3,11 +3,11 @@ Webhooks
 
 You can register webhooks to allow third party apps to be notified of helpdesk events. Webhooks can be registered in one of two ways:
 
-1. Setting the following environement variables to a comma separated list of URLs; ``HELPDESK_NEW_TICKET_WEBHOOK_URLS``& ``HELPDESK_FOLLOWUP_WEBHOOK_URLS``.
+1. Setting the following environment variables to a comma separated list of URLs; ``HELPDESK_NEW_TICKET_WEBHOOK_URLS``& ``HELPDESK_FOLLOWUP_WEBHOOK_URLS``.
 
 2. Adding getter functions to your ``settings.py``. These should return a list of strings (urls); ``HELPDESK_GET_NEW_TICKET_WEBHOOK_URLS`` & ``HELPDESK_GET_FOLLOWUP_WEBHOOK_URLS``.
 
-3. You can optionally set ``HELPDESK_WEBHOOK_TIMEOUT`` which defaults to 3 seconds. Warning, however, webhook requests are sent out sychronously on ticket update. If your webhook handling server is too slow, you should fix this rather than causing helpdesk freezes by messing with this variable.
+3. You can optionally set ``HELPDESK_WEBHOOK_TIMEOUT`` which defaults to 3 seconds. Warning, however, webhook requests are sent out synchronously on ticket update. If your webhook handling server is too slow, you should fix this rather than causing helpdesk freezes by messing with this variable.
 
 Once these URLs are configured, a serialized copy of the ticket object will be posted to each of these URLs each time a ticket is created or followed up on respectively.
 

--- a/src/helpdesk/lib.py
+++ b/src/helpdesk/lib.py
@@ -190,7 +190,7 @@ def process_attachments(followup, attached_files):
 
 
 def format_time_spent(time_spent):
-    """Format time_spent attribute to "[H]HHh:MMm" text string to be allign in
+    """Format time_spent attribute to "[H]HHh:MMm" text string to be align in
     all graphical outputs
     """
     if time_spent:

--- a/src/helpdesk/models.py
+++ b/src/helpdesk/models.py
@@ -290,7 +290,7 @@ class Queue(models.Model):
 
     permission_name = models.CharField(
         _("Django auth permission name"),
-        max_length=72,  # based on prepare_permission_name() pre-pending chars to slug
+        max_length=72,  # based on prepare_permission_name() prepending chars to slug
         blank=True,
         null=True,
         editable=False,
@@ -365,7 +365,7 @@ class Queue(models.Model):
         help_text=_(
             "If logging is enabled, what directory should we use to "
             "store log files for this queue? "
-            "The standard logging mechanims are used if no directory is set"
+            "The standard logging mechanisms are used if no directory is set"
         ),
     )
 
@@ -682,7 +682,7 @@ class Ticket(models.Model):
 
         **kwargs are passed to send_templated_mail defined in templated_email.py
 
-        returns the group of email addresses that wont be mailed to again, which is
+        returns the group of email addresses that won't be mailed to again, which is
         the addresses delivered to and dont_send_to and the queue address.
 
         """

--- a/src/helpdesk/templatetags/in_list.py
+++ b/src/helpdesk/templatetags/in_list.py
@@ -4,7 +4,7 @@ django-helpdesk - A Django powered ticket tracker for small enterprise.
 (c) Copyright 2008 Jutda. All Rights Reserved. See LICENSE for details.
 
 templatetags/in_list.py - Very simple template tag to allow us to use the
-                          equivilent of 'if x in y' in templates. eg:
+                          equivalent of 'if x in y' in templates. eg:
 
 Assuming 'food' = 'pizza' and 'best_foods' = ['pizza', 'pie', 'cake]:
 

--- a/src/helpdesk/update_ticket.py
+++ b/src/helpdesk/update_ticket.py
@@ -19,7 +19,7 @@ User = get_user_model()
 
 
 def add_staff_subscription(user: User, ticket: Ticket) -> None:
-    """Auto subscribe the staff member if that's what the settigs say and the
+    """Auto subscribe the staff member if that's what the settings say and the
     user is authenticated and a staff member"""
     if (
         helpdesk_settings.HELPDESK_AUTO_SUBSCRIBE_ON_TICKET_RESPONSE
@@ -94,7 +94,7 @@ def subscribe_to_ticket_updates(
 def get_and_set_ticket_status(
     new_status: int, ticket: Ticket, follow_up: FollowUp
 ) -> tuple[str, int]:
-    """Performs comparision on previous status to new status,
+    """Performs comparison on previous status to new status,
     updating the title as required.
 
     Returns:

--- a/src/helpdesk/views/staff.py
+++ b/src/helpdesk/views/staff.py
@@ -681,7 +681,7 @@ def get_ticket_from_request_with_authorisation(
 
 def get_due_date_from_form_or_ticket(form, ticket: Ticket) -> datetime.date | None:
     """Tries to locate the due date for a ticket from the form
-    'due_date' parameter or the `due_date_*` paramaters.
+    'due_date' parameter or the `due_date_*` parameters.
     """
     due_date = form.cleaned_data.get("due_date") or None
     if due_date is None:

--- a/standalone/config/settings.py
+++ b/standalone/config/settings.py
@@ -145,7 +145,7 @@ LOGIN_REDIRECT_URL = "helpdesk:home"
 
 
 DATABASES = {
-    # Setup postgress db with postgres as host and db name and read password from env var
+    # Setup postgresql db with postgres as host and db name and read password from env var
     "default": {
         "ENGINE": "django.db.backends.postgresql",
         "NAME": os.environ.get("POSTGRES_DB", "postgres"),

--- a/tests/test_get_email.py
+++ b/tests/test_get_email.py
@@ -336,7 +336,7 @@ class GetEmailCommonTests(TestCase):
 
         for att_retrieved in followup.followupattachment_set.all():
             if helpdesk.email.HTML_EMAIL_ATTACHMENT_FILENAME == att_retrieved.filename:
-                # Ignore the HTML formatted conntent of the email that is attached
+                # Ignore the HTML formatted content of the email that is attached
                 continue
             self.assertTrue(
                 att_retrieved.filename.endswith(att_filename),

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -13,7 +13,7 @@ class MarkDown(SimpleTestCase):
         self.assertEqual(output_value, expected_value)
 
     def test_markdown_nl2br(self):
-        """warning, after Line 1 - two withespace, esle did't work"""
+        """warning, after Line 1 - two withespace, else did't work"""
         expected_value = "<p>Line 1<br />\n                    Line 2</p>"
         input_value = """Line 1  
                     Line 2"""

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -24,7 +24,7 @@ from PIL import Image
 
 def strip_accents(text):
     """
-    Strip accents from input String. (only works on Pythin 3
+    Strip accents from input String. (only works on Python 3
 
     :param text: The input string.
     :type text: String.


### PR DESCRIPTION
Trying out [codespell](https://pypi.org/project/codespell/). I think it would take to much configuration here.

These are the typos I thought were worth fixing. 