### PR TITLE
fix: close the settings drift found in #1416

### DIFF
--- a/demodesk/config/settings.py
+++ b/demodesk/config/settings.py
@@ -105,8 +105,6 @@ HELPDESK_DEFAULT_SETTINGS = {
     "email_on_ticket_assign": True,
     "email_on_ticket_change": True,
     "login_view_ticketlist": True,
-    "email_on_ticket_apichange": True,
-    "preset_replies": True,
     "tickets_per_page": 25,
 }
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -86,6 +86,20 @@ Settings related to attachments
 
    If you'd like to turn of filtering of helpdesk extension types you can set this to ``False``.
 
+.. setting:: HELPDESK_ATTACHMENT_DIR_PERMS
+
+   *Default:* ``"755"``
+
+   Permissions used when creating the directories that hold ticket attachments, as an octal string. Parsed with base 8, so ``"755"`` means ``rwxr-xr-x``.
+
+.. setting:: HELPDESK_HTML_PREVIEW_ALLOW_REMOTE_IMAGES
+
+   *Default:* ``False``
+
+   Allow the HTML preview of a ticket message to load images from remote hosts. Off by default, which means a tracking pixel in a customer's e-mail does not fire when a staff member previews it. Set it to ``True`` only if full rendering fidelity matters more than that.
+
+   The preview is served with a ``Content-Security-Policy`` that sandboxes the document and disables scripting regardless of this setting. This toggle only widens ``img-src``.
+
 .. setting:: HELPDESK_ALWAYS_SAVE_INCOMING_EMAIL_MESSAGE
 
    *Default:* ``False``
@@ -125,6 +139,20 @@ These changes are visible throughout django-helpdesk
    *Default:* ``True``
 
    Show knowledgebase links?
+
+.. setting:: HELPDESK_UI_ENABLED
+
+   *Default:* ``True``
+
+   Register the web interface routes. Set it to ``False`` to serve the REST API without the staff and public web interface, for a deployment that drives django-helpdesk entirely from another front end.
+
+   Read when the URL configuration is built, so a change takes effect on the next process start rather than immediately.
+
+.. setting:: HELPDESK_USE_CDN
+
+   *Default:* ``False``
+
+   Serve jQuery and the other bundled JavaScript from public CDNs instead of the static files shipped with the package.
 
 .. setting:: HELPDESK_NAVIGATION_ENABLED
 
@@ -196,6 +224,12 @@ These changes are visible throughout django-helpdesk
 
    Maximum size, in bytes, of file attachments that will be sent via email
 
+.. setting:: HELPDESK_USE_HTTPS_IN_EMAIL_LINK
+
+   *Default:* the value of Django's ``SECURE_SSL_REDIRECT``
+
+   Scheme used for the ticket links in outgoing e-mail. ``True`` builds ``https://`` links, ``False`` builds ``http://``. The host comes from the current ``Site``, so that has to be configured as well for the links to be correct.
+
 .. setting:: QUEUE_EMAIL_BOX_UPDATE_ONLY
 
    *Default:* ``False``
@@ -213,6 +247,14 @@ These changes are visible throughout django-helpdesk
    *Default:* ``True``
 
    If False, disable the dependencies fields on ticket.
+
+.. setting:: HELPDESK_QUERY_CLASS
+
+   *Default:* django-helpdesk's own query class
+
+   A callable returning the class used to build and run ticket list queries. It is called with no arguments, and the class it returns is instantiated with the same signature as the built-in one. Use it to change how the ticket list is filtered and sorted without forking the views.
+
+   Resolved once when the staff views are imported, so a change takes effect on the next process start.
 
 .. setting:: HELPDESK_ENABLE_TIME_SPENT_ON_TICKET
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -202,6 +202,12 @@ These changes are visible throughout django-helpdesk
 
    Only process mail with a valid tracking ID; all other mail will be ignored instead of creating a new ticket.
 
+.. setting:: HELPDESK_FULL_FIRST_MESSAGE_FROM_EMAIL
+
+   *Default:* ``False``
+
+   Keep the forwarded and replied text of an incoming e-mail that creates a new ticket, instead of stripping it. Useful when a customer forwards an existing thread, an error report from another service for instance, and expects support to see all of it.
+
 .. setting:: HELPDESK_ENABLE_DEPENDENCIES_ON_TICKET
 
    *Default:* ``True``
@@ -691,7 +697,4 @@ The following settings were defined in previous versions and are no longer suppo
 
    Discontinued in favor of :setting:`HELPDESK_ENABLE_PER_QUEUE_STAFF_PERMISSION`.
 
-.. setting:: HELPDESK_FULL_FIRST_MESSAGE_FROM_EMAIL
-
-   Do not ignore forwarded and replied text from the email messages which create a new ticket; useful for cases when customer forwards some email (error from service or something) and wants support to see that
 

--- a/docs/standalone.rst
+++ b/docs/standalone.rst
@@ -156,7 +156,6 @@ Helpdesk Core Settings
    ``HELPDESK_EMAIL_ON_TICKET_ASSIGN``, ``True``, "Send email on ticket assignment"
    ``HELPDESK_EMAIL_ON_TICKET_CHANGE``, ``True``, "Send email on ticket changes"
    ``HELPDESK_LOGIN_VIEW_TICKETLIST``, ``True``, "Show ticket list after login"
-   ``HELPDESK_PRESET_REPLIES``, ``True``, "Enable preset replies"
    ``HELPDESK_TICKETS_PER_PAGE``, ``25``, "Number of tickets per page"
 
 Public Portal Settings

--- a/standalone/config/settings.py
+++ b/standalone/config/settings.py
@@ -115,7 +115,6 @@ HELPDESK_DEFAULT_SETTINGS = {
     == "True",
     "login_view_ticketlist": os.environ.get("HELPDESK_LOGIN_VIEW_TICKETLIST", "True")
     == "True",
-    "preset_replies": os.environ.get("HELPDESK_PRESET_REPLIES", "True") == "True",
     "tickets_per_page": os.environ.get("HELPDESK_TICKETS_PER_PAGE", "25"),
 }
 

--- a/standalone/config/settings.py
+++ b/standalone/config/settings.py
@@ -127,6 +127,9 @@ HELPDESK_SUBMIT_A_TICKET_PUBLIC = (
     os.environ.get("HELPDESK_SUBMIT_A_TICKET_PUBLIC", "True") == "True"
 )
 
+# Should the Kanban board be enabled?
+HELPDESK_KANBAN_ENABLED = os.environ.get("HELPDESK_KANBAN_ENABLED", "True") == "True"
+
 # Should the Knowledgebase be enabled?
 HELPDESK_KB_ENABLED = os.environ.get("HELPDESK_KB_ENABLED", "True") == "True"
 

--- a/tests/test_settings_drift.py
+++ b/tests/test_settings_drift.py
@@ -1,0 +1,176 @@
+"""Guards against drift between the places django-helpdesk settings live.
+
+The settings surface is spread across ``src/helpdesk``, two example
+configurations and the documentation, and until now nothing tied those together.
+``HELPDESK_PUBLIC_ENABLED`` sat in both configuration files and in the standalone
+documentation, described as the switch that enables the public portal, while no
+code in the package ever read it. See #1416.
+
+These checks are static analysis over files that are already in the repository.
+They cost nothing at runtime and fail as soon as a name is orphaned again. They
+are tripwires rather than proofs: a name mentioned only in a comment counts as
+used, which is the right trade for a check meant to catch whole settings falling
+out of use.
+
+They need the repository layout, so they skip when django-helpdesk is being
+tested from an installed distribution rather than from a checkout.
+"""
+
+import ast
+import re
+import unittest
+from pathlib import Path
+
+from django.test import SimpleTestCase
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PACKAGE = REPO_ROOT / "src" / "helpdesk"
+EXAMPLE_CONFIGS = (
+    REPO_ROOT / "standalone" / "config" / "settings.py",
+    REPO_ROOT / "demodesk" / "config" / "settings.py",
+)
+STANDALONE_CONFIG = EXAMPLE_CONFIGS[0]
+STANDALONE_DOCS = REPO_ROOT / "docs" / "standalone.rst"
+
+HELPDESK_SETTING = re.compile(r"^(HELPDESK|QUEUE)_")
+
+requires_checkout = unittest.skipUnless(
+    PACKAGE.is_dir() and all(p.is_file() for p in EXAMPLE_CONFIGS),
+    "needs the repository layout, not an installed distribution",
+)
+
+
+def _assigned_settings(path):
+    """HELPDESK_/QUEUE_ names a configuration file assigns at module level."""
+    tree = ast.parse(path.read_text())
+    return {
+        target.id
+        for node in tree.body
+        if isinstance(node, ast.Assign)
+        for target in node.targets
+        if isinstance(target, ast.Name) and HELPDESK_SETTING.match(target.id)
+    }
+
+
+def _default_user_settings_keys(path):
+    """Keys of the HELPDESK_DEFAULT_SETTINGS dict a configuration file defines."""
+    tree = ast.parse(path.read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and any(
+            isinstance(t, ast.Name) and t.id == "HELPDESK_DEFAULT_SETTINGS"
+            for t in node.targets
+        ):
+            return {k.value for k in node.value.keys if isinstance(k, ast.Constant)}
+    return set()
+
+
+def _environment_variables_read(path):
+    """Names a configuration file looks up in os.environ."""
+    tree = ast.parse(path.read_text())
+    names = set()
+    for node in ast.walk(tree):
+        # os.environ.get("NAME", default)
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "get"
+            and isinstance(node.func.value, ast.Attribute)
+            and node.func.value.attr == "environ"
+            and node.args
+            and isinstance(node.args[0], ast.Constant)
+        ):
+            names.add(node.args[0].value)
+        # os.environ["NAME"]
+        if (
+            isinstance(node, ast.Subscript)
+            and isinstance(node.value, ast.Attribute)
+            and node.value.attr == "environ"
+            and isinstance(node.slice, ast.Constant)
+        ):
+            names.add(node.slice.value)
+    return names
+
+
+def _package_sources():
+    for pattern in ("*.py", "*.html"):
+        yield from PACKAGE.rglob(pattern)
+
+
+class SettingsDriftTests(SimpleTestCase):
+    """The settings layers agree on which names exist."""
+
+    @requires_checkout
+    def test_example_configurations_only_set_settings_that_are_read(self):
+        """A name set by an example config is a name the package looks at.
+
+        This is the check that HELPDESK_PUBLIC_ENABLED failed.
+        """
+        package_text = "\n".join(
+            p.read_text(errors="replace") for p in _package_sources()
+        )
+
+        orphans = {}
+        for config in EXAMPLE_CONFIGS:
+            for name in _assigned_settings(config):
+                if not re.search(rf"\b{re.escape(name)}\b", package_text):
+                    orphans.setdefault(name, []).append(
+                        config.relative_to(REPO_ROOT).as_posix()
+                    )
+
+        self.assertEqual(
+            orphans,
+            {},
+            "these settings are assigned by an example configuration but no code "
+            "in src/helpdesk reads them, so setting them does nothing",
+        )
+
+    @requires_checkout
+    def test_documented_standalone_variables_are_read_by_the_image(self):
+        """Every variable the standalone docs promise is read by its settings file.
+
+        This is the check that HELPDESK_KANBAN_ENABLED failed: the tables listed
+        it under Feature Toggles while the configuration never looked at the
+        environment for it.
+        """
+        documented = set(
+            re.findall(r"^   ``(\w+)``,", STANDALONE_DOCS.read_text(), re.MULTILINE)
+        )
+        self.assertTrue(documented, "no variables found in the standalone tables")
+
+        # Read from the environment, specifically: a name hardcoded in the
+        # configuration would satisfy a plain text search while still ignoring
+        # whatever the operator puts in docker.env.
+        from_environment = _environment_variables_read(STANDALONE_CONFIG)
+        unread = sorted(documented - from_environment)
+
+        self.assertEqual(
+            unread,
+            [],
+            "docs/standalone.rst documents these environment variables but "
+            "standalone/config/settings.py never reads them",
+        )
+
+    @requires_checkout
+    def test_default_user_settings_keys_are_user_settings_fields(self):
+        """HELPDESK_DEFAULT_SETTINGS only carries keys UserSettings has.
+
+        DEFAULT_USER_SETTINGS.update() merges whatever it is given, so an
+        unknown key is absorbed in silence and never surfaces anywhere.
+        """
+        from helpdesk.models import UserSettings
+
+        fields = {f.name for f in UserSettings._meta.get_fields()}
+
+        unknown = {}
+        for config in EXAMPLE_CONFIGS:
+            for key in _default_user_settings_keys(config) - fields:
+                unknown.setdefault(key, []).append(
+                    config.relative_to(REPO_ROOT).as_posix()
+                )
+
+        self.assertEqual(
+            unknown,
+            {},
+            "these HELPDESK_DEFAULT_SETTINGS keys are not fields on the "
+            "UserSettings model, so nothing ever reads them",
+        )


### PR DESCRIPTION
The four quick fixes @uhurusurfa green-lit in #1416, one commit each.

## `HELPDESK_KANBAN_ENABLED` in the standalone image

`docs/standalone.rst` lists it under Feature Toggles, but `standalone/config/settings.py` never read the environment variable, so setting it in `docker.env` did nothing. The setting itself works: `src/helpdesk/settings.py:449` reads it, `urls.py:180` drops the kanban route, `navigation-sidebar.html:57` drops the sidebar link. The two neighbouring rows of the same table are wired, so this was an omission.

I had proposed removing the documented row instead. @DavidVadnais pointed out the setting is live, which turns the fix around: add the missing line.

## `HELPDESK_FULL_FIRST_MESSAGE_FROM_EMAIL` out of Discontinued Settings

`src/helpdesk/email.py:1136` still reads it. Same mistake I made with `HELPDESK_ALWAYS_SAVE_INCOMING_EMAIL_MESSAGE` in #1415, where I had only grepped `src/helpdesk/settings.py` and called it the sole survivor. Scanning the whole package, the remaining fifteen names in that section really are gone.

## Six settings nothing documented

Read by the code, absent from `docs/settings.rst` and from every other page under `docs/`, so the only way to find them was to read the source: `HELPDESK_UI_ENABLED`, `HELPDESK_USE_HTTPS_IN_EMAIL_LINK`, `HELPDESK_HTML_PREVIEW_ALLOW_REMOTE_IMAGES`, `HELPDESK_USE_CDN`, `HELPDESK_ATTACHMENT_DIR_PERMS`, `HELPDESK_QUERY_CLASS`.

Each goes in the section its neighbours are in. The two resolved at import time say so, since that is the kind of thing people discover by changing a value and seeing nothing happen.

## A test so this stops happening

Three static checks over files already in the repository:

1. every `HELPDESK_`/`QUEUE_` name an example configuration assigns is read by `src/helpdesk`. This is what `HELPDESK_PUBLIC_ENABLED` failed for years.
2. every environment variable the `docs/standalone.rst` tables promise is read from `os.environ` by `standalone/config/settings.py`. This is what `HELPDESK_KANBAN_ENABLED` failed. It inspects the environment reads rather than the file text, so a hardcoded value does not satisfy it.
3. every key of a `HELPDESK_DEFAULT_SETTINGS` dict is a field on `UserSettings`, since `DEFAULT_USER_SETTINGS.update()` merges whatever it is handed.

Each was verified to fail when its own regression is reintroduced. Check 3 turned up a third dead variable: `HELPDESK_PRESET_REPLIES` fed a `preset_replies` key that is not a `UserSettings` field, in both example configurations, plus `email_on_ticket_apichange` in the demo one. Removed, along with the documented row for the environment variable. The name `preset_replies` does exist elsewhere as a template context variable holding `PreSetReply` rows, which is unrelated and probably how it got there.

The checks are tripwires rather than proofs: a name appearing only in a comment counts as used, which is the right trade for catching a whole setting falling out of use. They skip when run against an installed distribution rather than a checkout.

## Verification

* full suite: 362 tests, OK
* `sphinx-build -W` clean
* `ruff check` and `ruff format --check` clean on the touched Python files

Closes the follow-up work in #1416.